### PR TITLE
refactor: remove debugging console calls

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -154,7 +154,6 @@ function Client() {
       call.qs.access_token = self.token;
     }
 
-    console.log(call);
     request(call, handleResponse(cb));
   }
 
@@ -167,8 +166,6 @@ function Client() {
           var parsed = JSON.parse(data);
           data = parsed;
         } catch (e) {
-          console.log(e);
-          console.log('error parsing response');
           return cb(new Error(data)); // sometimes errors are returned as strings.
         }
       }


### PR DESCRIPTION
`console.log` and similar shouldn't be included within an agnostic library, as they are for debugging purposes. This is especially unnecessary for errors since they can be caught by the client of this library. If such logs are desired, check out a module like [debug](https://github.com/visionmedia/debug).
