### PR TITLE
refactor: remove console#log calls from library

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -93,7 +93,7 @@ function Client() {
   var campaignTracking = {
     events: function(id, opts, cb) {
       if (!id || typeof(id) === "function") { return cb(new Error("id parameter must be provided.")); }
-    
+
       var call = {
         method: 'GET',
         url: self.baseUrl + '/email/public/v1/campaigns/' + id + '/events',
@@ -119,7 +119,7 @@ function Client() {
     getOne: function(id, appId, cb) {
       if (!id || typeof id === "function") { return cb(new Error("id parameter must be provided.")); }
       if (typeof appId === "function") { cb = appId; appId = null; }
-      
+
       var call = {
         method: 'GET',
         url: self.baseUrl + '/email/public/v1/campaigns/' + id
@@ -154,21 +154,18 @@ function Client() {
       call.qs.access_token = self.token;
     }
 
-    console.log(call);
     request(call, handleResponse(cb));
   }
 
   function handleResponse (cb) {
     return function (err, res, data) {
       if (err) { return cb(err); }
-      
+
       if (typeof data === 'string') {
         try {
           var parsed = JSON.parse(data);
           data = parsed;
         } catch (e) {
-          console.log(e);
-          console.log('error parsing response');
           return cb(new Error(data)); // sometimes errors are returned as strings.
         }
       }


### PR DESCRIPTION
the client of the library should handle this. all the values are passed
