### PR TITLE
refactor error and call handling

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,12 +10,18 @@ function Client() {
   self.baseUrl = defaultBaseUrl;
 
   function useToken (token) {
-    if (!token || typeof token !== 'string') { return cb(new Error("You must provide a token.")); }
+    if (!token || typeof token !== 'string') {
+      return cb(new Error("You must provide a token."));
+    }
+
     self.token = token;
   }
 
   function useKey (key) {
-    if (!key || typeof key !== 'string') { return cb(new Error("You must provide a key.")); }
+    if (!key || typeof key !== 'string') {
+      return cb(new Error("You must provide a key."));
+    }
+
     self.key = key;
   }
 
@@ -29,12 +35,12 @@ function Client() {
         cb = options;
         options = {};
       }
-      var call = {
+
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + 'contacts/v1/lists/all/contacts/all',
         qs: options
-      };
-      sendRequest(call, cb);
+      }, cb);
     }
   };
 
@@ -44,39 +50,44 @@ function Client() {
         cb = options;
         options = {};
       }
-      var call = {
+
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + 'contacts/v1/lists',
         qs: options
-      };
-      sendRequest(call, cb);
+      }, cb);
     },
-    post: notReadyError,
     getOne: function(id, cb) {
-      if (!id || typeof(id) === 'function') { return cb(new Error("id parameter must be provided.")); }
-      var call = {
+      if (!id || typeof(id) === 'function') {
+        return cb(new Error("id parameter must be provided."));
+      }
+
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + 'contacts/v1/lists/' + id,
-      };
-      sendRequest(call, cb);
+      }, cb);
     },
-    put: notReadyError,
-    del: notReadyError,
     getContacts: function(id, options, cb) {
-      if (!id || typeof(id) === 'function') { return cb(new Error("id parameter must be provided.")); }
+      if (!id || typeof(id) === 'function') {
+        return cb(new Error("id parameter must be provided."));
+      }
+
       if (typeof(options) === 'function') {
         cb = options;
         options = {};
       }
-      var call = {
+
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + 'contacts/v1/lists/' + id + '/contacts/all',
         qs: options
-      };
-      sendRequest(call, cb);
+      }, cb);
     },
     getRecentContacts: function(id, options, cb) {
-      if (!id || typeof(id) === 'function') { return cb(new Error("id parameter must be provided.")); }
+      if (!id || typeof(id) === 'function') {
+        return cb(new Error("id parameter must be provided."));
+      }
+
       if (typeof(options) === 'function') {
         cb = options;
         options = {};
@@ -92,14 +103,15 @@ function Client() {
 
   var campaignTracking = {
     events: function(id, opts, cb) {
-      if (!id || typeof(id) === "function") { return cb(new Error("id parameter must be provided.")); }
+      if (!id || typeof(id) === "function") {
+        return cb(new Error("id parameter must be provided."));
+      }
 
-      var call = {
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + '/email/public/v1/campaigns/' + id + '/events',
         qs: opts
-      };
-      sendRequest(call, cb);
+      }, cb);
     }
   };
 
@@ -109,26 +121,34 @@ function Client() {
         cb = options;
         options = {};
       }
-      var call = {
+
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + '/email/public/v1/campaigns',
         qs: options
-      };
-      sendRequest(call, cb);
+      }, cb);
     },
     getOne: function(id, appId, cb) {
-      if (!id || typeof id === "function") { return cb(new Error("id parameter must be provided.")); }
-      if (typeof appId === "function") { cb = appId; appId = null; }
+      if (!id || typeof id === "function") {
+        return cb(new Error("id parameter must be provided."));
+      }
+
+      if (typeof appId === "function") {
+        cb = appId;
+        appId = null;
+      }
 
       var call = {
         method: 'GET',
         url: self.baseUrl + '/email/public/v1/campaigns/' + id
       };
+
       if (appId) {
         call.qs = {
           appId: appId
         }
       }
+
       sendRequest(call, cb);
     },
     tracking: campaignTracking
@@ -141,13 +161,11 @@ function Client() {
         options = {};
       }
 
-      var call = {
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + '/email/public/v1/events',
         qs: options
-      };
-
-      sendRequest(call, cb);
+      }, cb);
     }
   };
 
@@ -158,13 +176,11 @@ function Client() {
         options = {};
       }
 
-      var call = {
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + '/companies/v2/companies/recent/created',
         qs: options
-      };
-
-      sendRequest(call, cb);
+      }, cb);
     }
   };
 
@@ -175,28 +191,27 @@ function Client() {
         options = {};
       }
 
-      var call = {
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + '/broadcast/v1/broadcasts',
         qs: options
-      };
-
-      sendRequest(call, cb);
+      }, cb);
     }
   };
 
   var files = {
     get: function(cb) {
-      var call = {
+      sendRequest({
         method: 'GET',
         url: self.baseUrl + '/content/api/v2/files'
-      };
-      sendRequest(call, cb);
+      }, cb);
     }
   };
 
   function sendRequest (call, cb) {
-    if (!self.key && !self.token) { return cb(new Error("You need to provide either a token or a key.")); }
+    if (!self.key && !self.token) {
+      return cb(new Error("You need to provide either a token or a key."));
+    }
 
     call.qs = call.qs || {};
     if (self.key) {
@@ -210,7 +225,7 @@ function Client() {
 
   function handleResponse (cb) {
     return function (err, res, data) {
-      if (err) { return cb(err); }
+      if (err) return cb(err);
 
       if (typeof data === 'string') {
         try {
@@ -221,26 +236,9 @@ function Client() {
         }
       }
 
-      if (data.error) {
-        var singleError = new Error(data.error);
-        singleError.response = data;
-        return cb(singleError);
-      }
-
-      if (data.length > 0 && data[0].error_message) {
-        var arrError = new Error(data[0].error_message);
-        arrError.response = data;
-        return cb(arrError);
-      }
-
       data.statusCode = res.statusCode;
       return cb(null, data);
     }
-  }
-
-  function notReadyError () {
-    var cb = arguments[arguments.length - 1];
-    return cb(new Error("this call is not ready yet."));
   }
 
   return {

--- a/lib/client.js
+++ b/lib/client.js
@@ -199,6 +199,21 @@ function Client() {
     }
   };
 
+  var subscriptions = {
+    get: function(options, cb) {
+      if (typeof options === 'function') {
+        cb = options;
+        options = {};
+      }
+
+      sendRequest({
+        method: 'GET',
+        url: self.baseUrl + '/email/public/v1/subscriptions/timeline',
+        qs: options
+      }, cb);
+    }
+  };
+
   var files = {
     get: function(cb) {
       sendRequest({
@@ -244,6 +259,7 @@ function Client() {
   return {
     campaigns: campaigns,
     events: events,
+    subscriptions: subscriptions,
     contacts: contacts,
     companies: companies,
     broadcasts: broadcasts,


### PR DESCRIPTION
@brainflake In contrast to my previous PR, rather than throwing HubSpot errors that vary in format from resource-to-resource, I think the API library should be low-level and return the HTTP responses as is from the `request` library and let the client handle them appropriately. This is the safest approach from my testing. Also, it doesn't make sense to return errors about a function not being ready- rather the function just shouldn't exist and should be created when ready. The library can be assumed to not cover the whole API with a notice in the README, as most wrappers don't since the API is ever-evolving. Did a bit of cleanup while I was at it ;)

I recommend that if you want to merge this PR, we merge it before releasing the changes w/ the PR that you just merged- #5... and then make a 0.1.0 release to github (from 0.0.5, that's semver breaking).
