### PR TITLE
defaulted api calls to OAuth2, with OAuth1 as opt

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -467,7 +467,13 @@ function Client(opts) {
     if (self.key) {
       call.qs.hapikey = self.key;
     } else if (self.token) {
-      call.qs.access_token = self.token;
+      if (self.opts.useOAuth1) {
+        call.qs.access_token = self.token;
+      } else {
+        call.auth = {
+          'bearer': self.token
+        }
+      }
     }
 
     Object.assign(call, self.opts.request);


### PR DESCRIPTION
-User can initialise client with opts.useOAuth1 == true 
-Otherwise all API calls will sent with token as bearer header

Refernce https://integrate.hubspot.com/t/any-of-the-listed-authentication-credentials-are-missing/2365/4