### PR TITLE
adds getByToken

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -85,6 +85,12 @@ function Client(opts) {
         qsStringifyOptions: { indices: false }
       }, cb);
     },
+    getByToken: function (token, cb) {
+      sendRequest({
+        method: 'GET',
+        url: self.baseUrl + '/contacts/v1/contact/utk/' + token + '/profile'
+      }, cb);
+    },
     update: function(id, data, cb) {
       sendRequest({
         method: 'POST',


### PR DESCRIPTION
Implements this method: https://developers.hubspot.com/docs/methods/contacts/get_contact_by_utk

Would add a test but it seems the hapi token is currently invalid.