### PR TITLE
[Company] Add Company Properties API

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ hubspot.companies.properties.get(cb)
 hubspot.companies.properties.getByName(name, cb)
 hubspot.companies.properties.create(data, cb)
 hubspot.companies.properties.update(name, data, cb)
-hubspot.companies.properties.update(name, data) // not an official API, wrapper doing two API calls. Callbacks not supported at this time
+hubspot.companies.properties.upsert(name, data) // not an official API, wrapper doing two API calls. Callbacks not supported at this time
 ```
 
 ### Contacts
@@ -124,7 +124,7 @@ hubspot.contacts.properties.get(cb)
 hubspot.contacts.properties.getByName(name, cb)
 hubspot.contacts.properties.create(data, cb)
 hubspot.contacts.properties.update(name, data, cb)
-hubspot.contacts.properties.update(name, data) // not an official API, wrapper doing two API calls. Callbacks not supported at this time
+hubspot.contacts.properties.upsert(name, data) // not an official API, wrapper doing two API calls. Callbacks not supported at this time
 ```
 
 ### Pages

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ hubspot.companies.addContactToCompany(data, cb); // data = { companyId: 123, con
 hubspot.companies.update(id, data, cb)
 ```
 
+### Company properties
+
+```javascript
+hubspot.companies.properties.get(cb)
+hubspot.companies.properties.getByName(name, cb)
+hubspot.companies.properties.create(data, cb)
+hubspot.companies.properties.update(name, data, cb)
+hubspot.companies.properties.update(name, data) // not an official API, wrapper doing two API calls. Callbacks not supported at this time
+```
+
 ### Contacts
 
 ```javascript

--- a/lib/company.js
+++ b/lib/company.js
@@ -1,6 +1,9 @@
+const Property = require('./company_property')
+
 class Company {
   constructor (client) {
     this.client = client
+    this.properties = new Property(this.client)
   }
 
   getById (id, cb) {

--- a/lib/company_property.js
+++ b/lib/company_property.js
@@ -1,0 +1,58 @@
+class Properties {
+  constructor (client) {
+    this.client = client
+  }
+
+  getAll (options, cb) {
+    if (typeof options === 'function') {
+      cb = options
+      options = {}
+    }
+
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/companies/properties',
+      qs: options
+    }, cb)
+  }
+
+  get (options, cb) {
+    return this.getAll(options, cb)
+  }
+
+  getByName (name, cb) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/companies/properties/named/' + name
+    }, cb)
+  }
+
+  create (data, cb) {
+    return this.client._request({
+      method: 'POST',
+      path: '/properties/v1/companies/properties',
+      body: data
+    }, cb)
+  }
+
+  update (name, data, cb) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/properties/v1/companies/properties/named/' + name,
+      body: data
+    }, cb)
+  }
+
+  upsert (data) {
+    return this.create(data)
+      .catch(err => {
+        if (err.statusCode === 409) { // if 409, the property already exists, update it
+          return this.update(data.name, data)
+        } else {
+          throw err
+        }
+      })
+  }
+}
+
+module.exports = Properties

--- a/test/company_properties.js
+++ b/test/company_properties.js
@@ -1,0 +1,82 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const Hubspot = require('..')
+const hubspot = new Hubspot({ apiKey: 'demo' })
+
+const property = {
+  name: 'mk_company_fit_segment',
+  label: 'MadKudu Company Fit',
+  groupName: 'companyinformation',
+  description: 'MadKudu Company Fit',
+  type: 'string',
+  fieldType: 'text',
+  formField: false,
+  displayOrder: -1,
+  options: []
+}
+
+describe('companies.properties', function () {
+  describe('get', function () {
+    it('should return the list of properties for companies', function () {
+      return hubspot.companies.properties.get().then(data => {
+        // console.log(data)
+        expect(data).to.be.an('array')
+        expect(data[0]).to.be.an('object')
+        expect(data[0]).to.have.a.property('name')
+      })
+    })
+  })
+
+  describe('getAll', function () {
+    it('should return the same thing as get', function () {
+      return hubspot.companies.properties.get().then(data => {
+        // console.log(data)
+        expect(data).to.be.an('array')
+        expect(data[0]).to.be.an('object')
+        expect(data[0]).to.have.a.property('name')
+      })
+    })
+  })
+
+  describe('getByName', function () {
+    let propertyName
+
+    before(() => {
+      return hubspot.companies.properties.get()
+        .then(results => {
+          // console.log(results)
+          propertyName = results[0].name
+        })
+    })
+
+    it('should get a property by name', function () {
+      return hubspot.companies.properties.getByName(propertyName).then(results => {
+        // console.log(results)
+        expect(results).to.be.an('object')
+        expect(results).to.have.a.property('name')
+      })
+    })
+  })
+
+  describe('upsert (create)', function () {
+    it('should create or update the property', function () {
+      return hubspot.companies.properties.upsert(property).then(data => {
+        expect(data).to.be.an('object')
+        expect(data).to.have.a.property('name')
+      })
+    })
+  })
+
+  describe('update', function () {
+    property.label = 'MadKudo Company Fit'
+
+    it('should update the property', function () {
+      return hubspot.companies.properties.update(property.name, property).then(data => {
+        expect(data).to.be.an('object')
+        expect(data).to.have.a.property('name')
+        expect(data.label).to.equal(property.label)
+      })
+    })
+  })
+})

--- a/test/contact_properties.js
+++ b/test/contact_properties.js
@@ -67,4 +67,16 @@ describe('contacts.properties', function () {
       })
     })
   })
+
+  describe('update', function () {
+    property.label = 'MadKudo Customer Fit'
+
+    it('should update the property', function () {
+      return hubspot.contacts.properties.update(property.name, property).then(data => {
+        expect(data).to.be.an('object')
+        expect(data).to.have.a.property('name')
+        expect(data.label).to.equal(property.label)
+      })
+    })
+  })
 })


### PR DESCRIPTION
Adds support for:

* get - [Get All Company Properties](https://developers.hubspot.com/docs/methods/companies/get_company_properties)
* getByName - [Get a Company Property](https://developers.hubspot.com/docs/methods/companies/get_company_property)
* create - [Create a company Property](https://developers.hubspot.com/docs/methods/companies/create_company_property)
* update - [Update a company Property](https://developers.hubspot.com/docs/methods/companies/update_company_property)

Things to note:

* Does not support property groups, you will have to know them ahead of time
* Does not support delete

I'd recommend this be a [minor (feature) release](http://semver.org/), as of this writing, `1.1.0`.