### PR TITLE
Fixed API limit issue

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -156,7 +156,7 @@ class Client extends EventEmitter {
       method: 'GET',
       path: '/integrations/v1/limit/daily'
     }).then(results => {
-      this.limit = results[0]
+      this.limit = results.filter((r) => r.name === 'api-calls-daily')[0];
       return this.limit
     })
   }


### PR DESCRIPTION
If you're a Hubspot user with multiple products, the API limit endpoint will return an array of products. Unfortunately, the CRM API limits isn't always the first value returned. 

This is what's returned when you hit the `https://api.hubapi.com/integrations/v1/limit/daily` endpoint (for our use case):

`[{"name":"api-calls-daily","usageLimit":40000,"currentUsage":119,"collectedAt":1510256051744,"fetchStatus":"SUCCESS","resetsAt":1510290000000},{"name":"sales-pro-seats","usageLimit":2,"currentUsage":2,"collectedAt":1510256051753,"fetchStatus":"SUCCESS","resetsAt":null}]`