### PR TITLE
contact.search and bottleneck

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,8 @@ const Subscription = require('./subscription')
 const _ = require('lodash')
 const request = require('request-promise')
 const EventEmitter = require('events').EventEmitter
+const Bottleneck = require('bottleneck')
+const limiter = new Bottleneck(9, 1000);
 
 const debug = require('debug')('hubspot:client')
 
@@ -49,7 +51,15 @@ class Client extends EventEmitter {
     this.oauth = new OAuth(this)
     this.owners = new Owner(this)
     this.pipelines = new Pipeline(this)
-    this.subscriptions = new Subscription(this)
+    this.subscriptions = new Subscription(this),
+    this.requestStats = requestStats
+  }
+
+  requestStats() {
+    return {
+      running: limiter.running(),
+      queued: limiter.queued()
+    };
   }
 
   setAccessToken (accessToken) {
@@ -98,7 +108,8 @@ class Client extends EventEmitter {
     return this.checkApiLimit(params)
       .then(() => {
         this.emit('apiCall', params)
-        return request(params)
+        // return request(params)
+        return limiter.schedule(() => request(params))
           .then(data => {
             if (typeof data === 'string') {
               let parsed

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,10 @@ const _ = require('lodash')
 const request = require('request-promise')
 const EventEmitter = require('events').EventEmitter
 const Bottleneck = require('bottleneck')
-const limiter = new Bottleneck(9, 1000);
+const limiter = new Bottleneck({
+  maxConcurrent: 9,
+  minTime: 1000
+})
 
 const debug = require('debug')('hubspot:client')
 
@@ -51,8 +54,7 @@ class Client extends EventEmitter {
     this.oauth = new OAuth(this)
     this.owners = new Owner(this)
     this.pipelines = new Pipeline(this)
-    this.subscriptions = new Subscription(this),
-    this.requestStats = requestStats
+    this.subscriptions = new Subscription(this)
   }
 
   requestStats() {
@@ -108,7 +110,7 @@ class Client extends EventEmitter {
     return this.checkApiLimit(params)
       .then(() => {
         this.emit('apiCall', params)
-        // return request(params)
+        // return request(params) // old call, not using limiter
         return limiter.schedule(() => request(params))
           .then(data => {
             if (typeof data === 'string') {

--- a/lib/company.js
+++ b/lib/company.js
@@ -59,10 +59,15 @@ class Company {
     }, cb)
   }
 
-  getByDomain (domain, cb) {
+  getByDomain (domain, data, cb) {
+    // return this.client._request({
+    //   method: 'GET',
+    //   path: '/companies/v2/companies/domain/' + domain
+    // }, cb)
     return this.client._request({
-      method: 'GET',
-      path: '/companies/v2/companies/domain/' + domain
+      method: 'POST',
+      path: '/companies/v2/domains/' + domain + '/companies',
+      body: data
     }, cb)
   }
 

--- a/lib/company.js
+++ b/lib/company.js
@@ -59,16 +59,17 @@ class Company {
     }, cb)
   }
 
-  getByDomain (domain, data, cb) {
-    // return this.client._request({
-    //   method: 'GET',
-    //   path: '/companies/v2/companies/domain/' + domain
-    // }, cb)
+  getByDomain (domain, cb) {
     return this.client._request({
-      method: 'POST',
-      path: '/companies/v2/domains/' + domain + '/companies',
-      body: data
+      method: 'GET',
+      path: '/companies/v2/companies/domain/' + domain
     }, cb)
+    // NEW: add "data" as param
+    // return this.client._request({
+    //   method: 'POST',
+    //   path: '/companies/v2/domains/' + domain + '/companies',
+    //   body: data
+    // }, cb)
   }
 
   create (data, cb) {

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -133,6 +133,21 @@ class Contact {
       qs: { q: query }
     }, cb)
   }
+
+  search (query, options, cb) {
+    if (typeof options === 'function') {
+      cb = options;
+      options = {};
+    }
+    options.q = query;
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/search/query',
+      // qs: { q: query }
+      qs: options
+    }, cb)
+  }
+
 }
 
 module.exports = Contact

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -126,14 +126,6 @@ class Contact {
     }, cb)
   }
 
-  search (query, cb) {
-    return this.client._request({
-      method: 'GET',
-      path: '/contacts/v1/search/query',
-      qs: { q: query }
-    }, cb)
-  }
-
   search (query, options, cb) {
     if (typeof options === 'function') {
       cb = options;
@@ -143,7 +135,6 @@ class Contact {
     return this.client._request({
       method: 'GET',
       path: '/contacts/v1/search/query',
-      // qs: { q: query }
       qs: options
     }, cb)
   }

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -131,6 +131,7 @@ class Contact {
       cb = options;
       options = {};
     }
+    if (!options) options = {};
     options.q = query;
     return this.client._request({
       method: 'GET',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,11 @@
         "hoek": "4.2.0"
       }
     },
+    "bottleneck": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.3.0.tgz",
+      "integrity": "sha512-Zxhe8FRIiFp5/uGRxIt/s26f6bm0Z87BWzPbUUZZGLkXOldRse1I/pqASYKjcth+6D1NOpVjaqD1X6aEqH+GCw=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -309,7 +314,7 @@
     },
     "co": {
       "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="
     },
     "color-convert": {
       "version": "1.9.1",
@@ -365,7 +370,7 @@
     },
     "core-util-is": {
       "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -728,7 +733,7 @@
     },
     "fast-deep-equal": {
       "version": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "integrity": "sha512-46+Jxk9Yj/nQY+3a1KTnpbBTemcAbPySTKya8iM9D7EsiONpSWbvzesalcCJ6tmJrCUITT2fmAQfNHFG+OHM6Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1128,7 +1133,7 @@
     },
     "json-schema-traverse": {
       "version": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1287,7 +1292,7 @@
     },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -1677,7 +1682,7 @@
     },
     "safe-buffer": {
       "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.2.5.3",
+  "version": "1.2.5",
   "description": "A node wrapper for the HubSpot API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.2.5",
+  "version": "1.2.5.1",
   "description": "A node wrapper for the HubSpot API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.2.5.2",
+  "version": "1.2.5.3",
   "description": "A node wrapper for the HubSpot API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.2.5.1",
+  "version": "1.2.5.2",
   "description": "A node wrapper for the HubSpot API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A node wrapper for the HubSpot API",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "bottleneck": "^2.3.0",
     "debug": "^3.1.0",
     "lodash": "^4.17.5",
     "request": "^2.83.0",


### PR DESCRIPTION
added contact.search functionality.

and bottleneck to limit the requests / user. Why? Beacuse the hubspot API has a rate limit based on requests per second. You get an error like this: 
"429 - {\"status\":\"error\",\"message\":\"You have reached your secondly limit.\",\"errorType\":\"RATE_LIMIT\",\"correlationId\":\"aedc0d29-ba1e-48e3-9fa0-9975c9131a7a\",\"groupName\":\"publicapi:hapikey-secondly:2431623\",\"policyName\":\"SECONDLY\",\"requestId\":\"632b866a6fc6454f32d5423a1166e92a\"}"

By adding bottleneck, a regular use case will not be impacted, but in case you make some bulk updates / requests it will magically solve all your problems.

Regards
Simon