### PR TITLE
Added "noUnusedLocals" and "noUnusedParameters" to the TSConfig file

### DIFF
--- a/lib/typescript/broadcast.ts
+++ b/lib/typescript/broadcast.ts
@@ -1,6 +1,5 @@
 import { RequestCallback } from 'request';
 import { RequestPromise } from 'request-promise';
-import { Groups } from './deal_property_group';
 
 declare class Broadcast {
   get(opts?: {}): RequestPromise;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,20 @@
 {
   "compilerOptions": {
-      "module": "commonjs",
-      "lib": [
-          "es6"
-      ],
-      "baseUrl": "./",
-      "noEmit": true,
-      "typeRoots": [
-          "./"
-      ],
-      "types": []
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "baseUrl": "./",
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "typeRoots": [
+      "./"
+    ],
+    "types": []
   },
   "files": [
-      "index.d.ts",
-      "test/typescript/hubspot.ts"
+    "index.d.ts",
+    "test/typescript/hubspot.ts"
   ]
 }


### PR DESCRIPTION
Hey,
I just got a compile error from Heroku:
`2018-06-29T09:24:52.600489+00:00 app[web.1]: node_modules/hubspot/lib/typescript/broadcast.ts(3,1): error TS6133: 'Groups' is declared but its value is never read.`

So I've added a few rules in the TSConfig (and fixed the indentation) to make sure it can't happen in future developments.
I went back to 1.2.8 for the time being.

Btw, I was happily surprised to see TypeScript support being added to this repo, but I already started some of the things I needed before you guys did. Even with API responses:
https://gist.github.com/harm-less/8b5c3cfa37cb7c0bede8c95e2fc1caf6
I only typed the things I needed so it's not finished, but I think having the responses typed as well makes it a lot more powerful. My intentions were to submit it to DefinitelyTyped someday, but haivng it here makes more sense. You can use my Gist if you like to.

Cheers