### PR TITLE
Typescript fixes

### DIFF
--- a/lib/typescript/broadcast.ts
+++ b/lib/typescript/broadcast.ts
@@ -1,6 +1,5 @@
 import { RequestCallback } from 'request';
 import { RequestPromise } from 'request-promise';
-import { Groups } from './deal_property_group';
 
 declare class Broadcast {
   get(opts?: {}): RequestPromise;

--- a/test/typescript/hubspot.ts
+++ b/test/typescript/hubspot.ts
@@ -1,13 +1,10 @@
 import Hubspot, {
   ApiOptions,
-  AccessTokenOptions,
   HubspotError,
 } from '../..';
 import { RequestError } from 'request-promise/errors';
 
-const apiKeyOptions: ApiOptions = { apiKey: 'apiKey' };
-const tokenOptions: AccessTokenOptions = { accessToken: 'token' };
-const baseUrlOptions: AccessTokenOptions = { accessToken: 'token', baseUrl: 'http://some-url' };
+const apiKeyOptions: ApiOptions = { apiKey: 'demo' };
 
 const handleResponse = (response) => {
   console.log(response);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,20 @@
 {
   "compilerOptions": {
-      "module": "commonjs",
-      "lib": [
-          "es6"
-      ],
-      "baseUrl": "./",
-      "noEmit": true,
-      "typeRoots": [
-          "./"
-      ],
-      "types": []
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "baseUrl": "./",
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "typeRoots": [
+      "./"
+    ],
+    "types": []
   },
   "files": [
-      "index.d.ts",
-      "test/typescript/hubspot.ts"
+    "index.d.ts",
+    "test/typescript/hubspot.ts"
   ]
 }


### PR DESCRIPTION
Remove unused parameters in typescript test file

Unfortunately, you can't ignore this compiler option like a lint option. See [here](Microsoft/TypeScript#11051).
While it would be nice to prove out that the access option defintion is working, there's a lot of things
that aren't included in this test file anyways so it needs to be revisited.

This also switches the hapi key to something that actually works.

This PR is the completion of: #97