### PR TITLE
Remove extra slash

### DIFF
--- a/lib/owner.js
+++ b/lib/owner.js
@@ -6,7 +6,7 @@ class Owner {
   get (cb) {
     return this.client._request({
       method: 'GET',
-      path: '/owners/v2/owners/'
+      path: '/owners/v2/owners'
     }, cb)
   }
 }


### PR DESCRIPTION
I have some tests on my own project that were using this endpoint and stubbing the response from this  request (using [nock](https://github.com/nock/nock)). I noticed I wasn't matching the request because of this extra slash.