### PR TITLE
Request: replace request-promise with requestretry

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,7 +13,7 @@ const Pipeline = require('./pipeline')
 const Subscription = require('./subscription')
 const Workflow = require('./workflow')
 const _ = require('lodash')
-const request = require('request-promise')
+const request = require('requestretry')
 const EventEmitter = require('events').EventEmitter
 const Bottleneck = require('bottleneck')
 const limiter = new Bottleneck({
@@ -108,6 +108,7 @@ class Client extends EventEmitter {
     }
 
     params.timeout = this.apiTimeout
+    params.fullResponse = false
 
     return this.checkApiLimit(params)
       .then(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,11 +228,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
     "bottleneck": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.3.0.tgz",
@@ -366,6 +361,7 @@
     },
     "co": {
       "version": "4.6.0",
+      "resolved": false,
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
@@ -1140,6 +1136,7 @@
     },
     "json-schema-traverse": {
       "version": "0.3.1",
+      "resolved": false,
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {
@@ -1605,23 +1602,15 @@
         "uuid": "^3.1.0"
       }
     },
-    "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+    "requestretry": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.13.0.tgz",
+      "integrity": "sha512-Lmh9qMvnQXADGAQxsXHP4rbgO6pffCfuR8XUBdP9aitJcLQJxhp7YZK4xAVYXnPJ5E52mwrfiKQtKonPL8xsmg==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "requires": {
-        "lodash": "^4.13.1"
+        "extend": "^3.0.0",
+        "lodash": "^4.15.0",
+        "request": "^2.74.0",
+        "when": "^3.7.7"
       }
     },
     "require-uncached": {
@@ -1790,11 +1779,6 @@
         "jsbn": "~0.1.0",
         "tweetnacl": "~0.14.0"
       }
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "2.1.1",
@@ -2000,6 +1984,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "when": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "^3.1.0",
     "lodash": "^4.17.5",
     "request": "^2.87.0",
-    "request-promise": "^4.2.2"
+    "requestretry": "^1.13.0"
   },
   "devDependencies": {
     "@types/node": "^10.5.1",


### PR DESCRIPTION
 This allows to auto catch & retry different server errors from hubspot.

Lately we see a lot of "TIMEDOUT" or "500 SERVER ERROR" with the hubspot client. This library change automatically retries "retryable" (ECONNRESET, ENOTFOUND, ESOCKETTIMEDOUT, ETIMEDOUT, ECONNREFUSED, EHOSTUNREACH, EPIPE, EAI_AGAIN or when an HTTP 5xx error occurrs) errors and therefore makes the use of this library way more reliable.

Regards
Simon