### PR TITLE
Correct update customer test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -317,6 +317,7 @@
     },
     "co": {
       "version": "4.6.0",
+      "resolved": false,
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
@@ -1152,6 +1153,7 @@
     },
     "json-schema-traverse": {
       "version": "0.3.1",
+      "resolved": false,
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {

--- a/test/contacts.js
+++ b/test/contacts.js
@@ -65,15 +65,12 @@ describe('contacts', function () {
 
     before(function () {
       return hubspot.contacts.get({ count: 10 }).then(data => {
-        // console.log(data)
         contactIds = _.map(data.contacts, 'vid')
       })
     })
 
     it('should return a contact record based on a array of ids', function () {
-      // console.log(contactIds)
       return hubspot.contacts.getByIdBatch(contactIds).then(data => {
-        // console.log(data)
         expect(data).to.be.an('object')
         expect(data).to.have.a.property(contactIds[0])
       })
@@ -92,27 +89,26 @@ describe('contacts', function () {
   describe('getByEmailBatch', function () {
     it('should return a contact record based on a array of emails', function () {
       return hubspot.contacts.getByEmailBatch(['testingapis@hubspot.com', 'testingapisawesomeandstuff@hubspot.com']).then(data => {
-        // console.log(data)
         expect(data).to.be.an('object')
       })
     })
   })
 
   describe('update', function () {
-    it('should update an existing contact', function () {
-      let contactId
+    let contactId
 
-      before(function () {
-        return hubspot.contacts.get().then(data => {
-          contactId = data.contacts[0].vid
-        })
+    before(function () {
+      return hubspot.contacts.get().then(data => {
+        contactId = data.contacts[0].vid
       })
+    })
 
+    it('should update an existing contact', function () {
       return hubspot.contacts.update(contactId, {
         'properties': [
           {
             'property': 'email',
-            'value': 'new-email@hubspot.com'
+            'value': `new-email${Date.now()}@hubspot.com`
           },
           {
             'property': 'firstname',
@@ -134,7 +130,6 @@ describe('contacts', function () {
           }
         ]
       }).then(data => {
-        console.log(data)
         expect(data).to.be.an('undefined')
       })
     })
@@ -218,7 +213,6 @@ describe('contacts', function () {
           }
         ]
       }).then(data => {
-        // console.log(data)
         expect(data).to.be.an('object')
         expect(data.properties.company.value).to.equal('MadKudu')
       })
@@ -239,7 +233,6 @@ describe('contacts', function () {
       }).then(data => {
         throw new Error('This should have failed')
       }).catch(err => {
-        // console.log(err)
         expect(err instanceof Error).to.equal(true)
         expect(err.error.message).to.equal('Contact already exists')
       })
@@ -293,9 +286,7 @@ describe('contacts', function () {
         const update = { vid: contact.vid, properties: [ { property: 'company', value: 'MadKudu ' } ] }
         return update
       })
-      // console.log(batch)
       return hubspot.contacts.createOrUpdateBatch(batch).then(data => {
-        // console.log(data)
         expect(data).to.equal(undefined)
       })
     })


### PR DESCRIPTION
Why:

It looks like the before call is happening in the incorrect place. This
means that the test never gets a valid customer to try and update.

This PR:

Moves the `before` call outside of `it`. The test then began to fail due
to the email not being unique so this change also adds the current
timestamp to the updated email.

This change also removes `console.log` calls.