### PR TITLE
Fetch contact Id Email for workflow tests

### DIFF
--- a/test/workflows.js
+++ b/test/workflows.js
@@ -6,8 +6,16 @@ const hubspot = new Hubspot({ apiKey: 'demo' })
 
 describe('workflows', function () {
   let workflowId = 2641273
-  let contactId = 860974
-  let contactEmail = 'test@gmail.com'
+  let contactId
+  let contactEmail
+
+  before(function () {
+    return hubspot.contacts.get().then(data => {
+      const firstContact = data.contacts[0]
+      contactId = firstContact.vid
+      contactEmail = firstContact['identity-profiles'][0].identities.find(obj => obj.type === 'EMAIL').value
+    })
+  })
 
   describe('get', function () {
     it('Should get all workflows', function () {


### PR DESCRIPTION
Why:

One of the workflow tests is failing because the contact `canonical-vid`
that we're using no longer exists.

This PR:

Changes the test to fetch an exisiting contact and use their
`canonical-vid` and `email` in the tests.
