### PR TITLE
Use an API_KEY for contact_properties

### DIFF
--- a/test/contact_properties.js
+++ b/test/contact_properties.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.API_KEY || 'demo' })
 
 const property = {
   name: 'mk_customer_fit_segment',


### PR DESCRIPTION
Why:

We have a failing test creating a group due to limits on the demo
account being reached.

This PR:

Uses a developer account for these tests if an environment variable has
been set.