### PR TITLE
Add mocks and test callback variation of broadcasts endpoint

### DIFF
--- a/test/broadcasts.js
+++ b/test/broadcasts.js
@@ -1,15 +1,34 @@
-const chai = require('chai')
-const expect = chai.expect
+const { expect } = require('chai')
+const nockHelper = require('./helpers/nock_helper')
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
 
 describe('broadcasts', function() {
   describe('get', function() {
+    before(nockHelper.mockEndpoint('/broadcast/v1/broadcasts', []))
+    after(nockHelper.resetNock)
+
     it('Should return details on a set of broadcast messages', function() {
-      return hubspot.broadcasts.get().then(data => {
-        expect(data).to.be.a('array')
-      })
+      const hubspot = new Hubspot({ apiKey: 'demo' })
+
+      return hubspot.broadcasts
+        .get()
+        .then(data => expect(data).to.be.a('array'))
+    })
+  })
+
+  describe('get with a callback', function() {
+    before(nockHelper.mockEndpoint('/broadcast/v1/broadcasts', []))
+    after(nockHelper.resetNock)
+
+    it('Should invoke the callback with the broadcasts', function() {
+      const hubspot = new Hubspot({ apiKey: 'demo' })
+      let result
+      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
+
+      return hubspot.broadcasts
+        .get(fakeCallback)
+        .then(() => expect(result).to.be.a('array'))
     })
   })
 })


### PR DESCRIPTION
Why:

Coverage for broadcasts is lacking because no tests are exercising the
callback portion of the API client.

PR:

This PR increases code coverage and uses the NockHelper instead of
hitting the API. It also cleans up the imports for chai.

Note:

Setting NOCK_OFF=true when running tests runs the tests against the
real API endpoints which can help a developer confirm that they are
hitting endpoints that actually exist.