### PR TITLE
Update travis to run coverage script and test-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 node_js: ["8.9.*"]
 
 before_script:
-  - npm install -g codeclimate-test-reporter
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 
 script:
   - npm run coverage
 
 after_success:
-  - codeclimate-test-reporter < ./coverage/lcov.info
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: node_js
 node_js: ["8.9.*"]
 
 before_script:
-- npm install -g istanbul
-- npm install -g mocha
-- npm install -g codeclimate-test-reporter
+  - npm install -g codeclimate-test-reporter
+
+script:
+  - npm run coverage
 
 after_success:
-  - istanbul cover _mocha -- -R spec ./test/*.js
   - codeclimate-test-reporter < ./coverage/lcov.info


### PR DESCRIPTION
Why:

We get the following deprecation warning when installing
codeclimate-test-reporter via npm:

``` npm WARN deprecated codeclimate-test-reporter@0.5.1: 
codeclimate-test-reporter has been deprecated in favor of our new unified
test-reporter. Please visit 
https://docs.codeclimate.com/docs/configuring-test-coverage for details on
setting up the new test-reporter.
```

This PR:

Updates to use the prebuilt binaries recommended by codeclimate. Also updates
the test script to run `coverage`

5cedf1c (Matthew Sumner, 9 minutes ago)