### PR TITLE
Email events un-runable code branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,9 @@ hubspot.subscriptions.get(opts, cb)
 ### Email Events
 
 ```javascript
+hubspot.campaigns.getById(cb)
 hubspot.campaigns.get(opts, cb)
-hubspot.campaigns.getOne(id, appId, cb)
+hubspot.campaigns.getOne(id, cb)
 hubspot.campaigns.events(opts, cb)
 ```
 

--- a/lib/campaign.js
+++ b/lib/campaign.js
@@ -35,28 +35,22 @@ class Campaign {
     )
   }
 
-  getOne(id, appId, cb) {
+  getOne(id, cb) {
     if (!id || typeof id === 'function') {
-      return cb(new Error('id parameter must be provided.'))
-    }
-
-    if (typeof appId === 'function') {
-      cb = appId
-      appId = null
-    }
-
-    var call = {
-      method: 'GET',
-      path: '/email/public/v1/campaigns/' + id,
-    }
-
-    if (appId) {
-      call.qs = {
-        appId: appId,
+      const error = new Error('id parameter must be provided.')
+      if (typeof id === 'function') {
+        id(error)
       }
+      return Promise.reject(error)
     }
 
-    return this.client._request(call, cb)
+    return this.client._request(
+      {
+        method: 'GET',
+        path: '/email/public/v1/campaigns/' + id,
+      },
+      cb,
+    )
   }
 
   events(options, cb) {

--- a/test/campaigns.js
+++ b/test/campaigns.js
@@ -1,43 +1,143 @@
-const chai = require('chai')
-const expect = chai.expect
-
+const { expect } = require('chai')
+const nockHelper = require('./helpers/nock_helper')
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = () =>
+  new Hubspot({
+    accessToken: process.env.ACCESS_TOKEN || 'fake-token',
+  })
 
 describe('campaigns', function() {
   describe('get', function() {
-    it('Should return campaign IDs with recent activity associated with the portal', function() {
-      return hubspot.campaigns.get().then(data => {
-        expect(data.campaigns).to.be.an('array')
-        expect(data.hasMore).to.equal(true)
-      })
+    beforeEach(
+      nockHelper.mockOauthEndpoint('/email/public/v1/campaigns', {
+        campaigns: [],
+      }),
+    )
+    afterEach(nockHelper.resetNock)
+
+    it('Should return campaigns with IDs', function() {
+      return hubspot()
+        .campaigns.get()
+        .then(data => {
+          expect(data.campaigns).to.be.an('array')
+        })
+    })
+
+    it('Should invoke a callback', function() {
+      let result
+      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
+
+      return hubspot()
+        .campaigns.get(fakeCallback)
+        .then(() => expect(result.campaigns).to.be.a('array'))
     })
   })
 
   describe('getOne', function() {
-    it('Should return campaign IDs with recent activity associated with the portal.', function() {
-      return hubspot.campaigns.getOne('by-id').then(data => {
-        expect(data.campaigns).to.be.an('array')
-        expect(data.hasMore).to.equal(true)
+    const hubspotDemo = new Hubspot({ apiKey: 'demo' })
+
+    describe('successfully', function() {
+      let campaignId
+
+      beforeEach(() => {
+        if (process.env.NOCK_OFF) {
+          return hubspotDemo.campaigns.get().then(data => {
+            campaignId = data.campaigns[0].id
+          })
+        } else {
+          campaignId = 123
+          nockHelper.mockEndpoint('/email/public/v1/campaigns/123', {
+            id: campaignId,
+          })()
+        }
+      })
+      afterEach(nockHelper.resetNock)
+
+      it('Should return a campaign', function() {
+        return hubspotDemo.campaigns.getOne(campaignId).then(data => {
+          expect(data.id).to.eq(campaignId)
+        })
+      })
+
+      it('Should take a callback as the second argument', function() {
+        let result
+        const fakeCallback = (_error, receivedValue) => (result = receivedValue)
+
+        return hubspotDemo.campaigns
+          .getOne(campaignId, fakeCallback)
+          .then(() => {
+            expect(result.id).to.eq(campaignId)
+          })
       })
     })
-  })
 
-  describe('events', function() {
-    it('Should return campaign IDs with recent activity associated with the portal', function() {
-      return hubspot.campaigns.events().then(data => {
-        expect(data.events).to.be.an('array')
-        expect(data.hasMore).to.equal(true)
+    describe('unsuccessfully', function() {
+      it('Should error when passed a callback as the first argument', function() {
+        let result
+        const fakeCallback = error => (result = error)
+
+        return hubspotDemo.campaigns.getOne(fakeCallback).catch(() => {
+          expect(result.message).to.eq('id parameter must be provided.')
+        })
+      })
+
+      it('Should error when not passed an id', function() {
+        return hubspotDemo.campaigns.getOne().catch(error => {
+          expect(error.message).to.eq('id parameter must be provided.')
+        })
       })
     })
   })
 
   describe('getById', function() {
-    // it('Should return campaign IDs with recent activity associated with the portal', function () {
-    //   return hubspot.campaigns.getById().then(data => {
-    //     expect(data.campaigns).to.be.an('array')
-    //     expect(data.hasMore).to.equal(true)
-    //   })
-    // })
+    beforeEach(
+      nockHelper.mockOauthEndpoint('/email/public/v1/campaigns/by-id', {
+        campaigns: [],
+      }),
+    )
+    afterEach(nockHelper.resetNock)
+
+    it('Should return a campaign', function() {
+      return hubspot()
+        .campaigns.getById()
+        .then(data => {
+          expect(data.campaigns).to.be.an('array')
+        })
+    })
+
+    it('Should invoke a callback', function() {
+      let result
+      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
+
+      return hubspot()
+        .campaigns.getById(fakeCallback)
+        .then(() => expect(result.campaigns).to.be.a('array'))
+    })
+  })
+
+  describe('events', function() {
+    beforeEach(
+      nockHelper.mockOauthEndpoint('/email/public/v1/events', {
+        events: [],
+      }),
+    )
+    afterEach(nockHelper.resetNock)
+
+    it('Should return events', function() {
+      return hubspot()
+        .campaigns.events()
+        .then(data => {
+          expect(data.events).to.be.an('array')
+        })
+    })
+
+    it('Should invoke a callback', function() {
+      let result
+      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
+
+      return hubspot()
+        .campaigns.events(fakeCallback)
+        .then(() => expect(result.events).to.be.a('array'))
+    })
   })
 })

--- a/test/helpers/nock_helper.js
+++ b/test/helpers/nock_helper.js
@@ -17,13 +17,14 @@ class NockHelper {
       ])
   }
 
-  mockEndpoint(path, data) {
+  mockEndpoint(path, data, query = {}) {
+    query.hapikey = 'demo'
     return () => {
       nock.disableNetConnect()
       this.mockRateLimit()
       nock('http://api.hubapi.com', { encodedQueryParams: true })
         .get(path)
-        .query({ hapikey: 'demo' })
+        .query(query)
         .reply(200, data)
     }
   }


### PR DESCRIPTION
Why:

While adding test coverage to the campaigns module, I found a couple of branches
that were not possible to reach.

This PR:

Adds the coverage for untested code branches and changes the implementation to
run with the expected input.