### PR TITLE
Extract fakeHubspotApi

### DIFF
--- a/test/broadcasts.js
+++ b/test/broadcasts.js
@@ -1,12 +1,15 @@
 const { expect } = require('chai')
-const nockHelper = require('./helpers/nock_helper')
 const Hubspot = require('..')
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
 
 describe('broadcasts', function() {
-  describe('get', function() {
-    before(nockHelper.mockOauthEndpoint('/broadcast/v1/broadcasts', []))
-    after(nockHelper.resetNock)
+  const broadcastsGetEndpoint = {
+    path: '/broadcast/v1/broadcasts',
+    response: [],
+  }
+  fakeHubspotApi.setupServer({ getEndpoints: [broadcastsGetEndpoint] })
 
+  describe('get', function() {
     it('Should return details on a set of broadcast messages', function() {
       const hubspot = new Hubspot({
         accessToken: process.env.ACCESS_TOKEN || 'fake-token',
@@ -19,9 +22,6 @@ describe('broadcasts', function() {
   })
 
   describe('get with a callback', function() {
-    before(nockHelper.mockOauthEndpoint('/broadcast/v1/broadcasts', []))
-    after(nockHelper.resetNock)
-
     it('Should invoke the callback with the broadcasts', function() {
       const hubspot = new Hubspot({
         accessToken: process.env.ACCESS_TOKEN || 'fake-token',

--- a/test/campaigns.js
+++ b/test/campaigns.js
@@ -1,6 +1,6 @@
-const { expect } = require('chai')
-const nockHelper = require('./helpers/nock_helper')
 const Hubspot = require('..')
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
+const { expect } = require('chai')
 const hubspot = () =>
   new Hubspot({
     accessToken: process.env.ACCESS_TOKEN || 'fake-token',
@@ -8,12 +8,11 @@ const hubspot = () =>
 
 describe('campaigns', function() {
   describe('get', function() {
-    beforeEach(
-      nockHelper.mockOauthEndpoint('/email/public/v1/campaigns', {
-        campaigns: [],
-      }),
-    )
-    afterEach(nockHelper.resetNock)
+    const campaignsGetEndpoint = {
+      path: '/email/public/v1/campaigns',
+      response: { campaigns: [] },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [campaignsGetEndpoint] })
 
     it('Should return campaigns with IDs', function() {
       return hubspot()
@@ -37,21 +36,23 @@ describe('campaigns', function() {
     const hubspotDemo = new Hubspot({ apiKey: 'demo' })
 
     describe('successfully', function() {
-      let campaignId
+      let campaignId = 345
+      const campaignGetEndpoint = {
+        path: `/email/public/v1/campaigns/${campaignId}`,
+        response: { id: campaignId },
+      }
+      fakeHubspotApi.setupServer({
+        demo: true,
+        getEndpoints: [campaignGetEndpoint],
+      })
 
       beforeEach(() => {
         if (process.env.NOCK_OFF) {
           return hubspotDemo.campaigns.get().then(data => {
             campaignId = data.campaigns[0].id
           })
-        } else {
-          campaignId = 123
-          nockHelper.mockEndpoint('/email/public/v1/campaigns/123', {
-            id: campaignId,
-          })()
         }
       })
-      afterEach(nockHelper.resetNock)
 
       it('Should return a campaign', function() {
         return hubspotDemo.campaigns.getOne(campaignId).then(data => {
@@ -90,12 +91,11 @@ describe('campaigns', function() {
   })
 
   describe('getById', function() {
-    beforeEach(
-      nockHelper.mockOauthEndpoint('/email/public/v1/campaigns/by-id', {
-        campaigns: [],
-      }),
-    )
-    afterEach(nockHelper.resetNock)
+    const campaignsByIdEndpoint = {
+      path: '/email/public/v1/campaigns/by-id',
+      response: { campaigns: [] },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [campaignsByIdEndpoint] })
 
     it('Should return a campaign', function() {
       return hubspot()
@@ -116,12 +116,11 @@ describe('campaigns', function() {
   })
 
   describe('events', function() {
-    beforeEach(
-      nockHelper.mockOauthEndpoint('/email/public/v1/events', {
-        events: [],
-      }),
-    )
-    afterEach(nockHelper.resetNock)
+    const eventsGetEndpoint = {
+      path: '/email/public/v1/events',
+      response: { events: [] },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [eventsGetEndpoint] })
 
     it('Should return events', function() {
       return hubspot()

--- a/test/helpers/fake_hubspot_api.js
+++ b/test/helpers/fake_hubspot_api.js
@@ -1,0 +1,33 @@
+const nockHelper = require('./nock_helper')
+
+class FakeHubSpotApi {
+  setupServer({
+    demo = false,
+    getEndpoints = [],
+    postEndpoints = [],
+    putEndpoints = [],
+  } = {}) {
+    let maybeAddHapiKeyToQuery = x => x
+    if (demo) {
+      maybeAddHapiKeyToQuery = parameters => {
+        parameters.query = parameters.query || {}
+        parameters.query.hapikey = parameters.query.hapikey || 'demo'
+        return parameters
+      }
+    }
+
+    beforeEach(function() {
+      nockHelper.disableNetConnect()
+      nockHelper.mockRateLimit()
+      getEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockGetEndpoint)
+      postEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockPostEndpoint)
+      putEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockPutEndpoint)
+    })
+
+    afterEach(function() {
+      nockHelper.resetNock()
+    })
+  }
+}
+
+module.exports = new FakeHubSpotApi()

--- a/test/owners.js
+++ b/test/owners.js
@@ -1,12 +1,12 @@
 const { expect } = require('chai')
-const nockHelper = require('./helpers/nock_helper')
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
 const Hubspot = require('..')
 
 describe('Owners', function() {
-  describe('get', function() {
-    before(nockHelper.mockEndpoint('/owners/v2/owners', []))
-    after(nockHelper.resetNock)
+  const ownersGetEndpoint = { path: '/owners/v2/owners', response: [] }
+  fakeHubspotApi.setupServer({ demo: true, getEndpoints: [ownersGetEndpoint] })
 
+  describe('get', function() {
     it('Should return all owners', function() {
       const hubspot = new Hubspot({ apiKey: 'demo' })
 
@@ -17,9 +17,6 @@ describe('Owners', function() {
   })
 
   describe('get with a callback', function() {
-    before(nockHelper.mockEndpoint('/owners/v2/owners', []))
-    after(nockHelper.resetNock)
-
     it('Should invoke the callback with the owners', function() {
       const hubspot = new Hubspot({ apiKey: 'demo' })
       let result


### PR DESCRIPTION
Why:

The tests are becoming noisey with all of the endpoint mocking.

This PR:

Extracts a single file to mock all of Hubspot's api and use that in our
tests.