### PR TITLE
Add clification for usuage of timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ hubspot.broadcasts.get(opts, cb)
 ### Timeline
 
 ```javascript
+// setup for timeline events
 hubspot.timelines.createEventType(applicationId, userId, data, cb)
 hubspot.timelines.updateEventType(applicationId, eventTypeId, data, cb)
 hubspot.timelines.createEventTypeProperty(
@@ -322,6 +323,7 @@ hubspot.timelines.updateEventTypeProperty(
   data,
   cb,
 )
+// creating timeline events
 hubspot.timelines.createTimelineEvent(applicationId, eventTypeId, data, cb)
 ```
 


### PR DESCRIPTION
Why:

It's not immediately clear that there is one function we expect most
users will be interested in for the timelines api.

This PR:

Adds comments to the usage in the README to clarify that three of the
timelines functions are for setup and one of them is the main usage.