### PR TITLE
Move contacts to use nock

### DIFF
--- a/test/contacts.js
+++ b/test/contacts.js
@@ -1,14 +1,61 @@
-const chai = require('chai')
-const expect = chai.expect
+const { expect } = require('chai')
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
-const _ = require('lodash')
+const emailsFromContacts = contacts =>
+  contacts.flatMap(contact =>
+    contact['identity-profiles'].map(
+      profile =>
+        profile.identities.find(identity => identity.type === 'EMAIL').value,
+    ),
+  )
 
 describe('contacts', function() {
-  this.timeout(10000)
+  const hubspot = new Hubspot({
+    accessToken: process.env.ACCESS_TOKEN || 'fake-token',
+  })
+  const createTestContact = () =>
+    hubspot.contacts.create({
+      properties: [
+        {
+          property: 'email',
+          value: 'node-hubspot' + Date.now() + '@madkudu.com',
+        },
+        {
+          property: 'firstname',
+          value: 'Try',
+        },
+        {
+          property: 'lastname',
+          value: 'MadKudu',
+        },
+        {
+          property: 'website',
+          value: 'http://www.madkudu.com',
+        },
+        {
+          property: 'company',
+          value: 'MadKudu',
+        },
+      ],
+    })
+  const deleteTestContact = contactId => hubspot.contacts.delete(contactId)
 
   describe('get', function() {
+    const count = 10
+    const contactsGetEndpoint = {
+      path: '/contacts/v1/lists/all/contacts/all',
+      response: { contacts: [{}] },
+    }
+    const tenContactsGetEndpoint = {
+      path: '/contacts/v1/lists/all/contacts/all',
+      response: { contacts: [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}] },
+      query: { count },
+    }
+    fakeHubspotApi.setupServer({
+      getEndpoints: [contactsGetEndpoint, tenContactsGetEndpoint],
+    })
+
     it('should return a batch of contacts', function() {
       return hubspot.contacts.get().then(data => {
         expect(data).to.be.a('object')
@@ -17,18 +64,24 @@ describe('contacts', function() {
       })
     })
 
-    it('should return the number of contacts requested', function() {
-      const count = 10
-      return hubspot.contacts.get({ count: 10 }).then(data => {
+    it('should pass through a count', function() {
+      return hubspot.contacts.get({ count }).then(data => {
         expect(data).to.be.a('object')
         expect(data.contacts).to.be.a('array')
-        expect(data.contacts).to.have.length(count)
       })
     })
   })
 
   describe('getRecentlyModified', function() {
-    it('should return last 100 updated contacts', function() {
+    const recentlyModifiedContactsGetEndpoint = {
+      path: '/contacts/v1/lists/recently_updated/contacts/recent',
+      response: { contacts: [{}] },
+    }
+    fakeHubspotApi.setupServer({
+      getEndpoints: [recentlyModifiedContactsGetEndpoint],
+    })
+
+    it('should return a list of contacts', function() {
       return hubspot.contacts.getRecentlyModified().then(data => {
         expect(data.contacts).to.be.an('array')
       })
@@ -36,7 +89,15 @@ describe('contacts', function() {
   })
 
   describe('getRecentlyCreated', function() {
-    it('should return last 100 updated contacts', function() {
+    const recentlyCreatedContactsGetEndpoint = {
+      path: '/contacts/v1/lists/all/contacts/recent',
+      response: { contacts: [{}] },
+    }
+    fakeHubspotApi.setupServer({
+      getEndpoints: [recentlyCreatedContactsGetEndpoint],
+    })
+
+    it('should return a list of contacts', function() {
       return hubspot.contacts.getRecentlyCreated().then(data => {
         expect(data.contacts).to.be.an('array')
       })
@@ -44,29 +105,46 @@ describe('contacts', function() {
   })
 
   describe('getById', function() {
-    let contactId
+    let contactId = 123
+    const contactByIdEndpoint = {
+      path: `/contacts/v1/contact/vid/${contactId}/profile`,
+      response: { vid: contactId },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [contactByIdEndpoint] })
 
     before(function() {
-      return hubspot.contacts.get().then(data => {
-        contactId = data.contacts[0].vid
-      })
+      if (process.env.NOCK_OFF) {
+        return createTestContact().then(data => (contactId = data.vid))
+      }
+    })
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return deleteTestContact(contactId)
+      }
     })
 
     it('should return a contact based on its id', function() {
       return hubspot.contacts.getById(contactId).then(data => {
         expect(data.vid).to.equal(contactId)
-        expect(data.properties.company).to.be.an('object')
       })
     })
   })
 
   describe('getByIdBatch', function() {
-    let contactIds
+    let contactIds = [123, 234, 345]
+    const contactsByIdsEndpoint = {
+      path: '/contacts/v1/contact/vids/batch',
+      response: { '123': {}, '234': {}, '345': {} },
+      query: { vid: contactIds },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [contactsByIdsEndpoint] })
 
     before(function() {
-      return hubspot.contacts.get({ count: 10 }).then(data => {
-        contactIds = _.map(data.contacts, 'vid')
-      })
+      if (process.env.NOCK_OFF) {
+        return hubspot.contacts.get({ count: 3 }).then(data => {
+          contactIds = data.contacts.map(contact => contact.vid)
+        })
+      }
     })
 
     it('should return a contact record based on a array of ids', function() {
@@ -78,119 +156,162 @@ describe('contacts', function() {
   })
 
   describe('getByEmail', function() {
-    it('should return a contact record based on the email', function() {
-      return hubspot.contacts
-        .getByEmail('testingapis@hubspot.com')
-        .then(data => {
-          expect(data).to.be.a('object')
-          expect(data.properties).to.be.a('object')
+    let email = 'testingapis@hubspot.com'
+    const contactByEmailEndpoint = {
+      path: `/contacts/v1/contact/email/${email}/profile`,
+      response: { properties: {} },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [contactByEmailEndpoint] })
+
+    before(function() {
+      if (process.env.NOCK_OFF) {
+        return hubspot.contacts.get({ count: 1 }).then(data => {
+          email = emailsFromContacts(data.contacts)[0]
         })
+      }
+    })
+
+    it('should return a contact record based on the email', function() {
+      return hubspot.contacts.getByEmail(email).then(data => {
+        expect(data).to.be.a('object')
+        expect(data.properties).to.be.a('object')
+      })
     })
   })
 
   describe('getByEmailBatch', function() {
-    it('should return a contact record based on a array of emails', function() {
-      return hubspot.contacts
-        .getByEmailBatch([
-          'testingapis@hubspot.com',
-          'testingapisawesomeandstuff@hubspot.com',
-        ])
-        .then(data => {
-          expect(data).to.be.an('object')
+    let emails = [
+      'testingapis@hubspot.com',
+      'testingapisawesomeandstuff@hubspot.com',
+    ]
+    const contactByEmailsEndpoint = {
+      path: '/contacts/v1/contact/emails/batch',
+      response: { properties: {} },
+      query: { email: emails },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [contactByEmailsEndpoint] })
+
+    before(function() {
+      if (process.env.NOCK_OFF) {
+        return hubspot.contacts.get({ count: 3 }).then(data => {
+          emails = emailsFromContacts(data.contacts)
         })
+      }
+    })
+
+    it('should return a contact record based on a array of emails', function() {
+      return hubspot.contacts.getByEmailBatch(emails).then(data => {
+        expect(data).to.be.an('object')
+      })
     })
   })
 
   describe('update', function() {
-    let contactId
+    let contactId = 123
+    const updateData = {
+      properties: [
+        {
+          property: 'email',
+          value: `new-email${Date.now()}@hubspot.com`,
+        },
+        {
+          property: 'firstname',
+          value: 'Updated',
+        },
+        {
+          property: 'lastname',
+          value: 'Lead',
+        },
+        {
+          property: 'website',
+          value: 'http://hubspot-updated-lead.com',
+        },
+        {
+          property: 'lifecyclestage',
+          value: 'customer',
+        },
+      ],
+    }
+    const updateContactEndpoint = {
+      path: `/contacts/v1/contact/vid/${contactId}/profile`,
+      request: updateData,
+      statusCode: 204,
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [updateContactEndpoint] })
 
     before(function() {
-      return hubspot.contacts.get().then(data => {
-        contactId = data.contacts[0].vid
-      })
+      if (process.env.NOCK_OFF) {
+        return hubspot.contacts.get().then(data => {
+          contactId = data.contacts[0].vid
+        })
+      }
     })
 
     it('should update an existing contact', function() {
-      return hubspot.contacts
-        .update(contactId, {
-          properties: [
-            {
-              property: 'email',
-              value: `new-email${Date.now()}@hubspot.com`,
-            },
-            {
-              property: 'firstname',
-              value: 'Updated',
-              timestamp: Date.now(),
-            },
-            {
-              property: 'lastname',
-              value: 'Lead',
-              timestamp: Date.now(),
-            },
-            {
-              property: 'website',
-              value: 'http://hubspot-updated-lead.com',
-            },
-            {
-              property: 'lifecyclestage',
-              value: 'customer',
-            },
-          ],
-        })
-        .then(data => {
-          expect(data).to.be.an('undefined')
-        })
+      return hubspot.contacts.update(contactId, updateData).then(data => {
+        expect(data).to.be.an('undefined')
+      })
     })
   })
 
   describe('createOrUpdate', function() {
+    const email = 'test@hubspot.com'
+    const createOrUpdateData = {
+      properties: [
+        {
+          property: 'email',
+          value: email,
+        },
+        {
+          property: 'firstname',
+          value: 'Matt',
+        },
+        {
+          property: 'lastname',
+          value: 'Schnitt',
+        },
+        {
+          property: 'website',
+          value: 'http://hubspot.com',
+        },
+        {
+          property: 'company',
+          value: 'HubSpot',
+        },
+        {
+          property: 'phone',
+          value: '555-122-2323',
+        },
+        {
+          property: 'address',
+          value: '25 First Street',
+        },
+        {
+          property: 'city',
+          value: 'Cambridge',
+        },
+        {
+          property: 'state',
+          value: 'MA',
+        },
+        {
+          property: 'zip',
+          value: '02139',
+        },
+      ],
+    }
+    const createOrUpdateContactEndpoint = {
+      path: `/contacts/v1/contact/createOrUpdate/email/${email}`,
+      request: createOrUpdateData,
+      response: {},
+    }
+    fakeHubspotApi.setupServer({
+      postEndpoints: [createOrUpdateContactEndpoint],
+    })
+
     it('should Create or Update a contact', function() {
       return hubspot.contacts
-        .createOrUpdate('test@hubspot.com', {
-          properties: [
-            {
-              property: 'email',
-              value: 'test@hubspot.com',
-            },
-            {
-              property: 'firstname',
-              value: 'Matt',
-            },
-            {
-              property: 'lastname',
-              value: 'Schnitt',
-            },
-            {
-              property: 'website',
-              value: 'http://hubspot.com',
-            },
-            {
-              property: 'company',
-              value: 'HubSpot',
-            },
-            {
-              property: 'phone',
-              value: '555-122-2323',
-            },
-            {
-              property: 'address',
-              value: '25 First Street',
-            },
-            {
-              property: 'city',
-              value: 'Cambridge',
-            },
-            {
-              property: 'state',
-              value: 'MA',
-            },
-            {
-              property: 'zip',
-              value: '02139',
-            },
-          ],
-        })
+        .createOrUpdate(email, createOrUpdateData)
         .then(data => {
           expect(data).to.be.an('object')
         })
@@ -198,52 +319,67 @@ describe('contacts', function() {
   })
 
   describe('create', function() {
+    const companyName = 'MadKudu'
+    const createData = {
+      properties: [
+        {
+          property: 'email',
+          value: 'node-hubspot' + Date.now() + '@madkudu.com',
+        },
+        {
+          property: 'firstname',
+          value: 'Try',
+        },
+        {
+          property: 'lastname',
+          value: 'MadKudu',
+        },
+        {
+          property: 'website',
+          value: 'http://www.madkudu.com',
+        },
+        {
+          property: 'company',
+          value: companyName,
+        },
+      ],
+    }
+    const createErrorData = {
+      properties: [
+        {
+          property: 'email',
+          value: 'node-hubspot@hubspot.com',
+        },
+        {
+          property: 'firstname',
+          value: 'Test',
+        },
+      ],
+    }
+    const createContactEndpoint = {
+      path: '/contacts/v1/contact',
+      request: createData,
+      response: { properties: { company: { value: companyName } } },
+    }
+    const createExisitingContactEndpoint = {
+      path: '/contacts/v1/contact',
+      request: createErrorData,
+      responseError: 'Contact already exists',
+    }
+    fakeHubspotApi.setupServer({
+      postEndpoints: [createContactEndpoint, createExisitingContactEndpoint],
+    })
+
     it('should create a new contact', function() {
-      return hubspot.contacts
-        .create({
-          properties: [
-            {
-              property: 'email',
-              value: 'node-hubspot' + Date.now() + '@madkudu.com',
-            },
-            {
-              property: 'firstname',
-              value: 'Try',
-            },
-            {
-              property: 'lastname',
-              value: 'MadKudu',
-            },
-            {
-              property: 'website',
-              value: 'http://www.madkudu.com',
-            },
-            {
-              property: 'company',
-              value: 'MadKudu',
-            },
-          ],
-        })
-        .then(data => {
-          expect(data).to.be.an('object')
-          expect(data.properties.company.value).to.equal('MadKudu')
-        })
+      return hubspot.contacts.create(createData).then(data => {
+        expect(data).to.be.an('object')
+        expect(data.properties.company.value).to.equal('MadKudu')
+      })
     })
 
     it('should fail if the contact already exists', function() {
       return hubspot.contacts
-        .create({
-          properties: [
-            {
-              property: 'email',
-              value: 'node-hubspot@hubspot.com',
-            },
-            {
-              property: 'firstname',
-              value: 'Test',
-            },
-          ],
-        })
+        .create(createErrorData)
         .then(data => {
           throw new Error('This should have failed')
         })
@@ -255,64 +391,68 @@ describe('contacts', function() {
   })
 
   describe('delete', function() {
+    let contactId = 123
+    const deleteContactEndpoint = {
+      path: `/contacts/v1/contact/vid/${contactId}`,
+      response: { vid: contactId },
+    }
+    fakeHubspotApi.setupServer({ deleteEndpoints: [deleteContactEndpoint] })
+
+    before(function() {
+      if (process.env.NOCK_OFF) {
+        return createTestContact().then(data => (contactId = data.vid))
+      }
+    })
+
     it('can delete', function() {
-      return hubspot.contacts
-        .create({
-          properties: [
-            {
-              property: 'email',
-              value: 'node-hubspot' + Date.now() + '@madkudu.com',
-            },
-            {
-              property: 'firstname',
-              value: 'Try',
-            },
-            {
-              property: 'lastname',
-              value: 'MadKudu',
-            },
-            {
-              property: 'website',
-              value: 'http://www.madkudu.com',
-            },
-            {
-              property: 'company',
-              value: 'MadKudu',
-            },
-          ],
-        })
-        .then(data => {
-          return hubspot.contacts.delete(data.vid)
-        })
+      return hubspot.contacts.delete(contactId).then(data => {
+        expect(data).to.be.an('object')
+      })
     })
   })
 
   describe('createOrUpdateBatch', function() {
-    // this.timeout(10000)
-
-    let contacts
+    const contactIds = [123, 234, 345]
+    const properties = [{ property: 'company', value: 'MadKudu ' }]
+    let createOrUpdateData = contactIds.map(vid => ({ vid, properties }))
+    const createOrUpdateContactsEndpoint = {
+      path: '/contacts/v1/contact/batch',
+      statusCode: 204,
+      request: createOrUpdateData,
+    }
+    fakeHubspotApi.setupServer({
+      postEndpoints: [createOrUpdateContactsEndpoint],
+    })
 
     before(function() {
-      return hubspot.contacts.get().then(data => {
-        contacts = data.contacts
-      })
+      if (process.env.NOCK_OFF) {
+        return hubspot.contacts.get({ count: 3 }).then(data => {
+          createOrUpdateData = data.contacts.map(({ vid }) => ({
+            vid,
+            properties,
+          }))
+        })
+      }
     })
 
     it('should update a batch of company', function() {
-      const batch = _.map(contacts, contact => {
-        const update = {
-          vid: contact.vid,
-          properties: [{ property: 'company', value: 'MadKudu ' }],
-        }
-        return update
-      })
-      return hubspot.contacts.createOrUpdateBatch(batch).then(data => {
-        expect(data).to.equal(undefined)
-      })
+      return hubspot.contacts
+        .createOrUpdateBatch(createOrUpdateData)
+        .then(data => {
+          expect(data).to.equal(undefined)
+        })
     })
   })
 
   describe('search', function() {
+    const query = 'example'
+    const searchContactsEndpoint = {
+      path: '/contacts/v1/search/query',
+      query: { q: query },
+      response: { contacts: [{}], query },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [searchContactsEndpoint] })
+
     it("should return contacts and some data associated with those contacts by the contact's email address or name.", function() {
       return hubspot.contacts.search('example').then(data => {
         expect(data.contacts).to.be.a('array')

--- a/test/helpers/fake_hubspot_api.js
+++ b/test/helpers/fake_hubspot_api.js
@@ -6,6 +6,7 @@ class FakeHubSpotApi {
     getEndpoints = [],
     postEndpoints = [],
     putEndpoints = [],
+    deleteEndpoints = [],
   } = {}) {
     let maybeAddHapiKeyToQuery = x => x
     if (demo) {
@@ -22,6 +23,9 @@ class FakeHubSpotApi {
       getEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockGetEndpoint)
       postEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockPostEndpoint)
       putEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockPutEndpoint)
+      deleteEndpoints
+        .map(maybeAddHapiKeyToQuery)
+        .map(nockHelper.mockDeleteEndpoint)
     })
 
     afterEach(function() {

--- a/test/helpers/nock_helper.js
+++ b/test/helpers/nock_helper.js
@@ -3,15 +3,23 @@ const nock = require('nock')
 const mockEndpoint = ({
   path,
   response,
+  responseError,
   verb,
   request,
   query = {},
   statusCode = 200,
 }) => {
-  nock('http://api.hubapi.com', { encodedQueryParams: true })
-    .intercept(path, verb, request)
-    .query(query)
-    .reply(statusCode, response)
+  if (responseError) {
+    nock('http://api.hubapi.com', { encodedQueryParams: true })
+      .intercept(path, verb, request)
+      .query(query)
+      .replyWithError(responseError)
+  } else {
+    nock('http://api.hubapi.com', { encodedQueryParams: true })
+      .intercept(path, verb, request)
+      .query(query)
+      .reply(statusCode, response)
+  }
 }
 
 class NockHelper {
@@ -49,6 +57,11 @@ class NockHelper {
 
   mockPutEndpoint(parameters) {
     parameters.verb = 'PUT'
+    mockEndpoint(parameters)
+  }
+
+  mockDeleteEndpoint(parameters) {
+    parameters.verb = 'DELETE'
     mockEndpoint(parameters)
   }
 


### PR DESCRIPTION
Why:

The contacts test failed on CI due to a contact no longer existing
https://travis-ci.org/MadKudu/node-hubspot/builds/469517133

This PR:

Moves the contacts tests to use nock and mock out the api calls.