### PR TITLE
Remove callbacks

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,30 +1,42 @@
-1.0.0 / 2017-08-23
-==================
+# 2.0.0 / 2018-12-19
 
-  * Added support for promises
-  * Added support for OAuth2
-  * Added convenience methods to support OAuth
-  * Tests working on demo instance of HubSpot
-  * Added support for some missing methods
+- Begins migration of test suite to mocked api calls instead of hitting HubSpot
+  "live"
+- Added support for some api endpoints such as timelines.
 
 Breaking changes:
-  * New instantation of client
-  * node > 6.10.0 required (see below)
+
+- Remove support for passing callbacks
+
+The usage of callbacks throughout node-hubspot was inconsistent in
+functionality. There was a lot of code to maintain callback support that we can
+remove now that promises are returned by all functions.
+
+# 1.0.0 / 2017-08-23
+
+- Added support for promises
+- Added support for OAuth2
+- Added convenience methods to support OAuth
+- Tests working on demo instance of HubSpot
+- Added support for some missing methods
+
+Breaking changes:
+
+- New instantiation of client
+- node > 6.10.0 required (see below)
 
 Notes:
 
-  * new version is ES2015 heavy and has only been tested in version of node > 6.10.0
-  * hasn't been tested in browser
-  * some babel magic would be needed for use in older versions of node (PR welcome!)
+- new version is ES2015 heavy and has only been tested in version of node > 6.10.0
+- hasn't been tested in browser
+- some babel magic would be needed for use in older versions of node (PR welcome!)
 
-0.3.0 / 2016-03-29
-==================
+# 0.3.0 / 2016-03-29
 
-  * Removed events.get() and campaigns.tracking.events() by merging them into campaigns.events()
+- Removed events.get() and campaigns.tracking.events() by merging them into campaigns.events()
 
-0.2.5 / 2016-03-25
-==================
+# 0.2.5 / 2016-03-25
 
-  * Added client.files.getOne()
-  * Fixed client.files.get()
-  * Updated README
+- Added client.files.getOne()
+- Fixed client.files.get()
+- Updated README

--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@
 
 Javascript / node.js wrapper for the [HubSpot API](https://developers.hubspot.com/docs/overview)
 
-## Upgrade to 1.0
-
-Version 1.0 was released on 2017-08-23 and included breaking changes. See the
-[Changelog](./changelog.md) for details.
-
-If you need help upgrading, please open an issue
-
 ## Installing
 
 ```shell
@@ -63,7 +56,8 @@ return hubspot.refreshAccessToken()
 
 ## Usage
 
-And then use the API method via:
+All methods return a [promise]. The success case includes the returned object
+from the response. Use the API method via:
 
 ```javascript
 hubspot.contacts
@@ -76,16 +70,7 @@ hubspot.contacts
   })
 ```
 
-or if you prefer callbacks:
-
-```javascript
-hubspot.contacts.get(function(err, results) {
-  if (err) {
-    console.error(err)
-  }
-  console.log(results)
-})
-```
+[promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
 ## {EXAMPLE} Create Contact
 
@@ -121,29 +106,29 @@ and will fail requests if the total is too close to the max. By default
 ### Companies
 
 ```javascript
-hubspot.companies.get(opts, cb)
-hubspot.companies.getById(id, cb)
-hubspot.companies.getRecentlyCreated(opts, cb)
-hubspot.companies.getRecentlyModified(opts, cb)
-hubspot.companies.getByDomain(domain, cb)
-hubspot.companies.create(data, cb)
-hubspot.companies.addContactToCompany(data, cb)
+hubspot.companies.get(opts)
+hubspot.companies.getById(id)
+hubspot.companies.getRecentlyCreated(opts)
+hubspot.companies.getRecentlyModified(opts)
+hubspot.companies.getByDomain(domain)
+hubspot.companies.create(data)
+hubspot.companies.addContactToCompany(data)
 // data = { companyId: 123, contactVid: 123 }
-hubspot.companies.getContactIds(id, options, cb)
-hubspot.companies.getContacts(id, options, cb)
-hubspot.companies.update(id, data, cb)
-hubspot.companies.updateBatch(data, cb)
+hubspot.companies.getContactIds(id, options)
+hubspot.companies.getContacts(id, options)
+hubspot.companies.update(id, data)
+hubspot.companies.updateBatch(data)
 // data = [{ objectId: 123, properties: [] }]
-hubspot.companies.delete(id, cb)
+hubspot.companies.delete(id)
 ```
 
 ### Company properties
 
 ```javascript
-hubspot.companies.properties.get(query, cb) // query is optional
-hubspot.companies.properties.getByName(name, cb)
-hubspot.companies.properties.create(data, cb)
-hubspot.companies.properties.update(name, data, cb)
+hubspot.companies.properties.get(query) // query is optional
+hubspot.companies.properties.getByName(name)
+hubspot.companies.properties.create(data)
+hubspot.companies.properties.update(name, data)
 hubspot.companies.properties.upsert(data)
 // not an official API, wrapper doing two API calls. Callbacks not supported
 // at this time.
@@ -152,9 +137,9 @@ hubspot.companies.properties.upsert(data)
 ### Company properties groups
 
 ```javascript
-hubspot.companies.properties.groups.get(query, cb) // query is optional
-hubspot.companies.properties.groups.create(data, cb)
-hubspot.companies.properties.groups.update(name, data, cb)
+hubspot.companies.properties.groups.get(query) // query is optional
+hubspot.companies.properties.groups.create(data)
+hubspot.companies.properties.groups.update(name, data)
 hubspot.companies.properties.groups.upsert(data)
 // not an official API, wrapper doing two API calls. Callbacks not supported at
 // this time
@@ -163,70 +148,70 @@ hubspot.companies.properties.groups.upsert(data)
 ### Contacts
 
 ```javascript
-hubspot.contacts.get(opts, cb)
-hubspot.contacts.getByEmail(email, cb)
-hubspot.contacts.getByEmailBatch(emails, cb)
-hubspot.contacts.getById(id, cb)
-hubspot.contacts.getByIdBatch(ids, cb)
-hubspot.contacts.getByToken(utk, cb)
-hubspot.contacts.update(id, data, cb)
-hubspot.contacts.create(data, cb)
-hubspot.contacts.createOrUpdateBatch(data, cb)
+hubspot.contacts.get(opts)
+hubspot.contacts.getByEmail(email)
+hubspot.contacts.getByEmailBatch(emails)
+hubspot.contacts.getById(id)
+hubspot.contacts.getByIdBatch(ids)
+hubspot.contacts.getByToken(utk)
+hubspot.contacts.update(id, data)
+hubspot.contacts.create(data)
+hubspot.contacts.createOrUpdateBatch(data)
 // data = [{ vid/email: '', properties: [] }]
-hubspot.contacts.search(query, cb)
-hubspot.contacts.getRecentlyCreated(cb)
-hubspot.contacts.getRecentlyModified(cb)
-hubspot.contacts.createOrUpdate(email, data, cb)
-hubspot.contacts.delete(id, cb)
+hubspot.contacts.search(query)
+hubspot.contacts.getRecentlyCreated()
+hubspot.contacts.getRecentlyModified()
+hubspot.contacts.createOrUpdate(email, data)
+hubspot.contacts.delete(id)
 ```
 
 ### Contact properties
 
 ```javascript
-hubspot.contacts.properties.get(cb)
-hubspot.contacts.properties.getByName(name, cb)
-hubspot.contacts.properties.create(data, cb)
-hubspot.contacts.properties.update(name, data, cb)
+hubspot.contacts.properties.get()
+hubspot.contacts.properties.getByName(name)
+hubspot.contacts.properties.create(data)
+hubspot.contacts.properties.update(name, data)
 hubspot.contacts.properties.upsert(data)
 // not an official API, wrapper doing two API calls.
 // Callbacks not supported at this time
-hubspot.contacts.properties.getGroups(cb)
+hubspot.contacts.properties.getGroups()
 // => [ {name: '...', displayName: '...'}, ...]
-hubspot.contacts.properties.createGroup({ name, displayName }, cb)
-hubspot.contacts.properties.updateGroup(name, { displayName }, cb)
-hubspot.contacts.properties.deleteGroup(name, cb)
-hubspot.contacts.properties.delete(name, cb)
+hubspot.contacts.properties.createGroup({ name, displayName })
+hubspot.contacts.properties.updateGroup(name, { displayName })
+hubspot.contacts.properties.deleteGroup(name)
+hubspot.contacts.properties.delete(name)
 ```
 
 ### Pages
 
 ```javascript
 // more opts can be found at https://developers.hubspot.com/docs/methods/pages/get_pages
-hubspot.pages.get(opts, cb) // eg: opts = {is_draft: false}
+hubspot.pages.get(opts) // eg: opts = {is_draft: false}
 ```
 
 ### Deals
 
 ```javascript
-hubspot.deals.get(opts, cb)
-hubspot.deals.getRecentlyModified(opts, cb)
-hubspot.deals.getRecentlyCreated(opts, cb)
-hubspot.deals.getById(id, cb)
-hubspot.deals.getAssociated(objectType, objectId, opts, cb)
-hubspot.deals.deleteById(id, cb)
-hubspot.deals.updateById(id, data, cb)
-hubspot.deals.create(data, cb)
-hubspot.deals.associate(id, objectType, associatedObjectId, cb)
-hubspot.deals.removeAssociation(id, objectType, associatedObjectId, cb)
+hubspot.deals.get(opts)
+hubspot.deals.getRecentlyModified(opts)
+hubspot.deals.getRecentlyCreated(opts)
+hubspot.deals.getById(id)
+hubspot.deals.getAssociated(objectType, objectId, opts)
+hubspot.deals.deleteById(id)
+hubspot.deals.updateById(id, data)
+hubspot.deals.create(data)
+hubspot.deals.associate(id, objectType, associatedObjectId)
+hubspot.deals.removeAssociation(id, objectType, associatedObjectId)
 ```
 
 ### Deals properties
 
 ```javascript
-hubspot.deals.properties.get(query, cb) // query is optional
-hubspot.deals.properties.getByName(name, cb)
-hubspot.deals.properties.create(data, cb)
-hubspot.deals.properties.update(name, data, cb)
+hubspot.deals.properties.get(query) // query is optional
+hubspot.deals.properties.getByName(name)
+hubspot.deals.properties.create(data)
+hubspot.deals.properties.update(name, data)
 hubspot.deals.properties.upsert(data)
 // not an official API, wrapper doing two API calls. Callbacks not supported at
 // this time
@@ -235,9 +220,9 @@ hubspot.deals.properties.upsert(data)
 ### Deals properties groups
 
 ```javascript
-hubspot.deals.properties.groups.get(query, cb) // query is optional
-hubspot.deals.properties.groups.create(data, cb)
-hubspot.deals.properties.groups.update(name, data, cb)
+hubspot.deals.properties.groups.get(query) // query is optional
+hubspot.deals.properties.groups.create(data)
+hubspot.deals.properties.groups.update(name, data)
 hubspot.deals.properties.groups.upsert(data)
 // not an official API, wrapper doing two API calls. Callbacks not supported at
 // this time
@@ -246,85 +231,83 @@ hubspot.deals.properties.groups.upsert(data)
 ### Engagements
 
 ```javascript
-hubspot.engagements.create(data, cb)
-hubspot.engagements.get(opts, cb)
-hubspot.engagements.getRecentlyModified(opts, cb)
-hubspot.engagements.getAssociated(objectType, objectId, opts, cb)
-hubspot.engagements.getCallDispositions(cb)
+hubspot.engagements.create(data)
+hubspot.engagements.get(opts)
+hubspot.engagements.getRecentlyModified(opts)
+hubspot.engagements.getAssociated(objectType, objectId, opts)
+hubspot.engagements.getCallDispositions()
 ```
 
 ### Owners
 
 ```javascript
-hubspot.owners.get(opts, cb)
+hubspot.owners.get(opts)
 ```
 
 ### Pipelines
 
 ```javascript
-hubspot.pipelines.get(opts, cb)
+hubspot.pipelines.get(opts)
 ```
 
 ### Lists
 
 ```javascript
-hubspot.lists.get(opts, cb)
-hubspot.lists.getOne(id, cb)
-hubspot.lists.getContacts(id, opts, cb)
-hubspot.lists.getRecentContacts(id, opts, cb)
-hubspot.lists.addContacts(id, contactBody, cb)
+hubspot.lists.get(opts)
+hubspot.lists.getOne(id)
+hubspot.lists.getContacts(id, opts)
+hubspot.lists.getRecentContacts(id, opts)
+hubspot.lists.addContacts(id, contactBody)
 ```
 
 ### Files
 
 ```javascript
-hubspot.files.get(cb)
-hubspot.files.getOne(id, cb)
+hubspot.files.get()
+hubspot.files.getOne(id)
 ```
 
 ### Email
 
 ```javascript
-hubspot.subscriptions.get(opts, cb)
+hubspot.subscriptions.get(opts)
 ```
 
 ### Email Events
 
 ```javascript
-hubspot.campaigns.getById(cb)
-hubspot.campaigns.get(opts, cb)
-hubspot.campaigns.getOne(id, cb)
-hubspot.campaigns.events(opts, cb)
+hubspot.campaigns.getById()
+hubspot.campaigns.get(opts)
+hubspot.campaigns.getOne(id)
+hubspot.campaigns.events(opts)
 ```
 
 ### Social Media
 
 ```javascript
-hubspot.broadcasts.get(opts, cb)
+hubspot.broadcasts.get(opts)
 ```
 
 ### Timeline
 
 ```javascript
 // setup for timeline events
-hubspot.timelines.createEventType(applicationId, userId, data, cb)
-hubspot.timelines.updateEventType(applicationId, eventTypeId, data, cb)
+hubspot.timelines.createEventType(applicationId, userId, data)
+hubspot.timelines.updateEventType(applicationId, eventTypeId, data)
 hubspot.timelines.createEventTypeProperty(
   applicationId,
   eventTypeId,
   userId,
   data,
-  cb,
 )
 hubspot.timelines.updateEventTypeProperty(
   applicationId,
   eventTypeId,
   propertyId,
   data,
-  cb,
 )
 // creating timeline events
-hubspot.timelines.createTimelineEvent(applicationId, eventTypeId, data, cb)
+hubspot.timelines.createTimelineEvent(applicationId, eventTypeId, data)
 ```
 
 NOTE: From the [documentation] for createTimelineEvent:
@@ -333,14 +316,14 @@ NOTE: From the [documentation] for createTimelineEvent:
 > more details about the specific error in the body of the response.
 
 So on success the body is empty or `undefined` and you will not get a result
-passed to a provided callback function
+from the resolved promise.
 
 [documentation]: https://developers.hubspot.com/docs/methods/timeline/create-or-update-event
 
 ### Transactional Emails
 
 ```javascript
-hubspot.emails.sendTransactionalEmail(data, cb)
+hubspot.emails.sendTransactionalEmail(data)
 ```
 
 ### OAuth

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -3,20 +3,12 @@ class Broadcast {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/broadcast/v1/broadcasts',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/broadcast/v1/broadcasts',
+      qs: options,
+    })
   }
 }
 

--- a/lib/campaign.js
+++ b/lib/campaign.js
@@ -3,39 +3,23 @@ class Campaign {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/email/public/v1/campaigns',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/email/public/v1/campaigns',
+      qs: options,
+    })
   }
 
-  getById(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/email/public/v1/campaigns/by-id',
-        qs: options,
-      },
-      cb,
-    )
+  getById(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/email/public/v1/campaigns/by-id',
+      qs: options,
+    })
   }
 
-  getOne(id, cb) {
+  getOne(id) {
     if (!id || typeof id === 'function') {
       const error = new Error('id parameter must be provided.')
       if (typeof id === 'function') {
@@ -44,29 +28,18 @@ class Campaign {
       return Promise.reject(error)
     }
 
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/email/public/v1/campaigns/' + id,
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'GET',
+      path: '/email/public/v1/campaigns/' + id,
+    })
   }
 
-  events(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/email/public/v1/events',
-        qs: options,
-      },
-      cb,
-    )
+  events(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/email/public/v1/events',
+      qs: options,
+    })
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,7 +102,7 @@ class Client extends EventEmitter {
     }
   }
 
-  _request(opts, cb = () => {}) {
+  _request(opts) {
     const params = _.cloneDeep(opts)
     if (this.auth) {
       params.auth = this.auth
@@ -121,16 +121,7 @@ class Client extends EventEmitter {
 
     return this.checkApiLimit(params).then(() => {
       this.emit('apiCall', params)
-      return limiter
-        .schedule(() => request(params)) // limit the number of concurrent requests
-        .then(body => {
-          cb(null, body)
-          return body
-        })
-        .catch(err => {
-          cb(err)
-          throw err
-        })
+      return limiter.schedule(() => request(params)) // limit the number of concurrent requests
     })
   }
 

--- a/lib/company.js
+++ b/lib/company.js
@@ -6,172 +6,113 @@ class Company {
     this.properties = new Property(this.client)
   }
 
-  getById(id, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/companies/v2/companies/' + id,
+  getById(id) {
+    return this.client._request({
+      method: 'GET',
+      path: '/companies/v2/companies/' + id,
+    })
+  }
+
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/companies/v2/companies/paged',
+      qs: options,
+      qsStringifyOptions: {
+        arrayFormat: 'repeat',
       },
-      cb,
-    )
+    })
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/companies/v2/companies/paged',
-        qs: options,
-        qsStringifyOptions: {
-          arrayFormat: 'repeat',
-        },
-      },
-      cb,
-    )
+  getAll(options) {
+    return this.get(options)
   }
 
-  getAll(options, cb) {
-    return this.get(options, cb)
+  getRecentlyCreated(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/companies/v2/companies/recent/created',
+      qs: options,
+    })
   }
 
-  getRecentlyCreated(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/companies/v2/companies/recent/created',
-        qs: options,
-      },
-      cb,
-    )
+  getRecentlyModified(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/companies/v2/companies/recent/modified',
+      qs: options,
+    })
   }
 
-  getRecentlyModified(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/companies/v2/companies/recent/modified',
-        qs: options,
-      },
-      cb,
-    )
+  getByDomain(domain) {
+    return this.client._request({
+      method: 'GET',
+      path: '/companies/v2/companies/domain/' + domain,
+    })
   }
 
-  getByDomain(domain, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/companies/v2/companies/domain/' + domain,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/companies/v2/companies/',
+      body: data,
+    })
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/companies/v2/companies/',
-        body: data,
-      },
-      cb,
-    )
+  delete(id) {
+    return this.client._request({
+      method: 'DELETE',
+      path: '/companies/v2/companies/' + id,
+    })
   }
 
-  delete(id, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path: '/companies/v2/companies/' + id,
-      },
-      cb,
-    )
+  update(id, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/companies/v2/companies/' + id,
+      body: data,
+    })
   }
 
-  update(id, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/companies/v2/companies/' + id,
-        body: data,
-      },
-      cb,
-    )
+  updateBatch(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/companies/v1/batch-async/update',
+      body: data,
+    })
   }
 
-  updateBatch(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/companies/v1/batch-async/update',
-        body: data,
-      },
-      cb,
-    )
-  }
-
-  addContactToCompany(data, cb) {
+  addContactToCompany(data) {
     if (!data || !data.companyId || !data.contactVid) {
-      return cb(new Error('companyId and contactVid params must be provided'))
+      return Promise.reject(
+        new Error('companyId and contactVid params must be provided'),
+      )
     }
 
-    return this.client._request(
-      {
-        method: 'PUT',
-        path:
-          '/companies/v2/companies/' +
-          data.companyId +
-          '/contacts/' +
-          data.contactVid,
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'PUT',
+      path:
+        '/companies/v2/companies/' +
+        data.companyId +
+        '/contacts/' +
+        data.contactVid,
+    })
   }
 
-  getContactIds(id, options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/companies/v2/companies/' + id + '/vids',
-        qs: options,
-      },
-      cb,
-    )
+  getContactIds(id, options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/companies/v2/companies/' + id + '/vids',
+      qs: options,
+    })
   }
 
-  getContacts(id, options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/companies/v2/companies/' + id + '/contacts',
-        qs: options,
-      },
-      cb,
-    )
+  getContacts(id, options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/companies/v2/companies/' + id + '/contacts',
+      qs: options,
+    })
   }
 }
 

--- a/lib/company_property.js
+++ b/lib/company_property.js
@@ -6,56 +6,39 @@ class Properties {
     this.groups = new Group(this.client)
   }
 
-  getAll(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/companies/properties',
-        qs: options,
-      },
-      cb,
-    )
+  getAll(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/companies/properties',
+      qs: options,
+    })
   }
 
-  get(options, cb) {
-    return this.getAll(options, cb)
+  get(options) {
+    return this.getAll(options)
   }
 
-  getByName(name, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/companies/properties/named/' + name,
-      },
-      cb,
-    )
+  getByName(name) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/companies/properties/named/' + name,
+    })
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/properties/v1/companies/properties',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/properties/v1/companies/properties',
+      body: data,
+    })
   }
 
-  update(name, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/properties/v1/companies/properties/named/' + name,
-        body: data,
-      },
-      cb,
-    )
+  update(name, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/properties/v1/companies/properties/named/' + name,
+      body: data,
+    })
   }
 
   upsert(data) {

--- a/lib/company_property_group.js
+++ b/lib/company_property_group.js
@@ -3,46 +3,32 @@ class Groups {
     this.client = client
   }
 
-  getAll(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/companies/groups',
-        qs: options,
-      },
-      cb,
-    )
+  getAll(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/companies/groups',
+      qs: options,
+    })
   }
 
-  get(options, cb) {
-    return this.getAll(options, cb)
+  get(options) {
+    return this.getAll(options)
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/properties/v1/companies/groups',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/properties/v1/companies/groups',
+      body: data,
+    })
   }
 
-  update(name, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/properties/v1/companies/groups/named/' + name,
-        body: data,
-      },
-      cb,
-    )
+  update(name, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/properties/v1/companies/groups/named/' + name,
+      body: data,
+    })
   }
 
   upsert(data) {

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -6,180 +6,121 @@ class Contact {
     this.properties = new Property(this.client)
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/lists/all/contacts/all',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/lists/all/contacts/all',
+      qs: options,
+    })
   }
 
-  getAll(options, cb) {
-    return this.get(options, cb)
+  getAll(options) {
+    return this.get(options)
   }
 
-  getRecentlyModified(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/lists/recently_updated/contacts/recent',
-        qs: options,
-      },
-      cb,
-    )
+  getRecentlyModified(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/lists/recently_updated/contacts/recent',
+      qs: options,
+    })
   }
 
-  getRecentlyCreated(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/lists/all/contacts/recent',
-        qs: options,
-      },
-      cb,
-    )
+  getRecentlyCreated(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/lists/all/contacts/recent',
+      qs: options,
+    })
   }
 
-  getByEmail(email, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/contact/email/' + email + '/profile',
-      },
-      cb,
-    )
+  getByEmail(email) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/contact/email/' + email + '/profile',
+    })
   }
 
-  getByEmailBatch(emails, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/contact/emails/batch',
-        qs: { email: emails },
-        qsStringifyOptions: { indices: false },
-      },
-      cb,
-    )
+  getByEmailBatch(emails) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/contact/emails/batch',
+      qs: { email: emails },
+      qsStringifyOptions: { indices: false },
+    })
   }
 
-  getById(id, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/contact/vid/' + id + '/profile',
-      },
-      cb,
-    )
+  getById(id) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/contact/vid/' + id + '/profile',
+    })
   }
 
-  getByIdBatch(ids, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/contact/vids/batch',
-        qs: { vid: ids },
-        qsStringifyOptions: { indices: false },
-      },
-      cb,
-    )
+  getByIdBatch(ids) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/contact/vids/batch',
+      qs: { vid: ids },
+      qsStringifyOptions: { indices: false },
+    })
   }
 
-  getByToken(token, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/contact/utk/' + token + '/profile',
-      },
-      cb,
-    )
+  getByToken(token) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/contact/utk/' + token + '/profile',
+    })
   }
 
-  delete(id, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path: '/contacts/v1/contact/vid/' + id,
-      },
-      cb,
-    )
+  delete(id) {
+    return this.client._request({
+      method: 'DELETE',
+      path: '/contacts/v1/contact/vid/' + id,
+    })
   }
 
-  update(id, data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/contacts/v1/contact/vid/' + id + '/profile',
-        body: data,
-      },
-      cb,
-    )
+  update(id, data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/contacts/v1/contact/vid/' + id + '/profile',
+      body: data,
+    })
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/contacts/v1/contact',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/contacts/v1/contact',
+      body: data,
+    })
   }
 
-  createOrUpdate(email, data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/contacts/v1/contact/createOrUpdate/email/' + email,
-        body: data,
-      },
-      cb,
-    )
+  createOrUpdate(email, data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/contacts/v1/contact/createOrUpdate/email/' + email,
+      body: data,
+    })
   }
 
   // note: response to successful batch update is undefined by design : http://developers.hubspot.com/docs/methods/contacts/batch_create_or_update
-  createOrUpdateBatch(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/contacts/v1/contact/batch',
-        body: data,
-      },
-      cb,
-    )
+  createOrUpdateBatch(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/contacts/v1/contact/batch',
+      body: data,
+    })
   }
 
-  search(query, options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
+  search(query, options) {
     if (!options) options = {}
     options.q = query
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/search/query',
-        qs: options,
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/search/query',
+      qs: options,
+    })
   }
 }
 

--- a/lib/contact_property.js
+++ b/lib/contact_property.js
@@ -3,66 +3,46 @@ class Properties {
     this.client = client
   }
 
-  getAll(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v2/properties',
-        qs: options,
-      },
-      cb,
-    )
+  getAll(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v2/properties',
+      qs: options,
+    })
   }
 
-  get(options, cb) {
-    return this.getAll(options, cb)
+  get(options) {
+    return this.getAll(options)
   }
 
-  getByName(name, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/contacts/properties/named/' + name,
-      },
-      cb,
-    )
+  getByName(name) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/contacts/properties/named/' + name,
+    })
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/properties/v1/contacts/properties',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/properties/v1/contacts/properties',
+      body: data,
+    })
   }
 
-  update(name, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/properties/v1/contacts/properties/named/' + name,
-        body: data,
-      },
-      cb,
-    )
+  update(name, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/properties/v1/contacts/properties/named/' + name,
+      body: data,
+    })
   }
 
-  delete(name, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path: '/properties/v1/contacts/properties/named/' + name,
-      },
-      cb,
-    )
+  delete(name) {
+    return this.client._request({
+      method: 'DELETE',
+      path: '/properties/v1/contacts/properties/named/' + name,
+    })
   }
 
   upsert(data) {
@@ -76,46 +56,34 @@ class Properties {
     })
   }
 
-  getGroups(cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/contacts/groups',
-      },
-      cb,
-    )
+  getGroups() {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/contacts/groups',
+    })
   }
 
-  createGroup(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/properties/v1/contacts/groups',
-        body: data,
-      },
-      cb,
-    )
+  createGroup(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/properties/v1/contacts/groups',
+      body: data,
+    })
   }
 
-  updateGroup(name, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/properties/v1/contacts/groups/named/' + name,
-        body: data,
-      },
-      cb,
-    )
+  updateGroup(name, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/properties/v1/contacts/groups/named/' + name,
+      body: data,
+    })
   }
 
-  deleteGroup(name, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path: '/properties/v1/contacts/groups/named/' + name,
-      },
-      cb,
-    )
+  deleteGroup(name) {
+    return this.client._request({
+      method: 'DELETE',
+      path: '/properties/v1/contacts/groups/named/' + name,
+    })
   }
 }
 

--- a/lib/deal.js
+++ b/lib/deal.js
@@ -6,140 +6,94 @@ class Deal {
     this.properties = new Property(client)
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/deals/v1/deal/paged',
-        qs: options,
-        useQuerystring: true,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/deals/v1/deal/paged',
+      qs: options,
+      useQuerystring: true,
+    })
   }
 
-  getRecentlyModified(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/deals/v1/deal/recent/modified',
-        qs: options,
-      },
-      cb,
-    )
+  getRecentlyModified(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/deals/v1/deal/recent/modified',
+      qs: options,
+    })
   }
 
-  getRecentlyCreated(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/deals/v1/deal/recent/created',
-        qs: options,
-      },
-      cb,
-    )
+  getRecentlyCreated(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/deals/v1/deal/recent/created',
+      qs: options,
+    })
   }
 
-  getById(id, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/deals/v1/deal/' + id,
-      },
-      cb,
-    )
+  getById(id) {
+    return this.client._request({
+      method: 'GET',
+      path: '/deals/v1/deal/' + id,
+    })
   }
 
-  getAssociated(objectType, objectId, options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-    return this.client._request(
-      {
-        method: 'GET',
-        path:
-          '/deals/v1/deal/associated/' + objectType + '/' + objectId + '/paged',
-        qs: options,
-      },
-      cb,
-    )
+  getAssociated(objectType, objectId, options) {
+    return this.client._request({
+      method: 'GET',
+      path:
+        '/deals/v1/deal/associated/' + objectType + '/' + objectId + '/paged',
+      qs: options,
+    })
   }
 
-  deleteById(id, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path: '/deals/v1/deal/' + id,
-      },
-      cb,
-    )
+  deleteById(id) {
+    return this.client._request({
+      method: 'DELETE',
+      path: '/deals/v1/deal/' + id,
+    })
   }
 
-  updateById(id, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/deals/v1/deal/' + id,
-        body: data,
-      },
-      cb,
-    )
+  updateById(id, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/deals/v1/deal/' + id,
+      body: data,
+    })
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/deals/v1/deal/',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/deals/v1/deal/',
+      body: data,
+    })
   }
 
-  associate(id, objectType, associatedObjectId, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path:
-          '/deals/v1/deal/' +
-          id +
-          '/associations/' +
-          objectType +
-          '?id=' +
-          associatedObjectId,
-      },
-      cb,
-    )
+  associate(id, objectType, associatedObjectId) {
+    return this.client._request({
+      method: 'PUT',
+      path:
+        '/deals/v1/deal/' +
+        id +
+        '/associations/' +
+        objectType +
+        '?id=' +
+        associatedObjectId,
+    })
   }
 
-  removeAssociation(id, objectType, associatedObjectId, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path:
-          '/deals/v1/deal/' +
-          id +
-          '/associations/' +
-          objectType +
-          '?id=' +
-          associatedObjectId,
-      },
-      cb,
-    )
+  removeAssociation(id, objectType, associatedObjectId) {
+    return this.client._request({
+      method: 'DELETE',
+      path:
+        '/deals/v1/deal/' +
+        id +
+        '/associations/' +
+        objectType +
+        '?id=' +
+        associatedObjectId,
+    })
   }
 }
 

--- a/lib/deal_property.js
+++ b/lib/deal_property.js
@@ -6,66 +6,46 @@ class Properties {
     this.groups = new Group(this.client)
   }
 
-  getAll(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/deals/properties',
-        qs: options,
-      },
-      cb,
-    )
+  getAll(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/deals/properties',
+      qs: options,
+    })
   }
 
-  get(options, cb) {
-    return this.getAll(options, cb)
+  get(options) {
+    return this.getAll(options)
   }
 
-  getByName(name, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/deals/properties/named/' + name,
-      },
-      cb,
-    )
+  getByName(name) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/deals/properties/named/' + name,
+    })
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/properties/v1/deals/properties',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/properties/v1/deals/properties',
+      body: data,
+    })
   }
 
-  update(name, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/properties/v1/deals/properties/named/' + name,
-        body: data,
-      },
-      cb,
-    )
+  update(name, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/properties/v1/deals/properties/named/' + name,
+      body: data,
+    })
   }
 
-  delete(name, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path: '/properties/v1/deals/properties/named/' + name,
-      },
-      cb,
-    )
+  delete(name) {
+    return this.client._request({
+      method: 'DELETE',
+      path: '/properties/v1/deals/properties/named/' + name,
+    })
   }
 
   upsert(data) {

--- a/lib/deal_property_group.js
+++ b/lib/deal_property_group.js
@@ -3,46 +3,32 @@ class DealGroups {
     this.client = client
   }
 
-  getAll(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/properties/v1/deals/groups',
-        qs: options,
-      },
-      cb,
-    )
+  getAll(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/properties/v1/deals/groups',
+      qs: options,
+    })
   }
 
-  get(options, cb) {
-    return this.getAll(options, cb)
+  get(options) {
+    return this.getAll(options)
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/properties/v1/deals/groups',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/properties/v1/deals/groups',
+      body: data,
+    })
   }
 
-  update(name, data, cb) {
-    return this.client._request(
-      {
-        method: 'PUT',
-        path: '/properties/v1/deals/groups/named/' + name,
-        body: data,
-      },
-      cb,
-    )
+  update(name, data) {
+    return this.client._request({
+      method: 'PUT',
+      path: '/properties/v1/deals/groups/named/' + name,
+      body: data,
+    })
   }
 
   upsert(data) {

--- a/lib/emails.js
+++ b/lib/emails.js
@@ -3,15 +3,12 @@ class Email {
     this.client = client
   }
 
-  sendTransactionalEmail(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/email/public/v1/singleEmail/send',
-        body: data,
-      },
-      cb,
-    )
+  sendTransactionalEmail(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/email/public/v1/singleEmail/send',
+      body: data,
+    })
   }
 }
 

--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -3,78 +3,48 @@ class Engagement {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/engagements/v1/engagements/paged',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/engagements/v1/engagements/paged',
+      qs: options,
+    })
   }
 
-  getRecentlyModified(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/engagements/v1/engagements/recent/modified',
-        qs: options,
-      },
-      cb,
-    )
+  getRecentlyModified(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/engagements/v1/engagements/recent/modified',
+      qs: options,
+    })
   }
 
-  getAssociated(objectType, objectId, options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path:
-          '/engagements/v1/engagements/associated/' +
-          objectType +
-          '/' +
-          objectId +
-          '/paged',
-        qs: options,
-      },
-      cb,
-    )
+  getAssociated(objectType, objectId, options) {
+    return this.client._request({
+      method: 'GET',
+      path:
+        '/engagements/v1/engagements/associated/' +
+        objectType +
+        '/' +
+        objectId +
+        '/paged',
+      qs: options,
+    })
   }
 
-  create(data, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/engagements/v1/engagements',
-        body: data,
-      },
-      cb,
-    )
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/engagements/v1/engagements',
+      body: data,
+    })
   }
 
-  getCallDispositions(cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/calling/v1/dispositions',
-      },
-      cb,
-    )
+  getCallDispositions() {
+    return this.client._request({
+      method: 'GET',
+      path: '/calling/v1/dispositions',
+    })
   }
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -3,28 +3,18 @@ class File {
     this.client = client
   }
 
-  get(cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/filemanager/api/v2/files',
-      },
-      cb,
-    )
+  get() {
+    return this.client._request({
+      method: 'GET',
+      path: '/filemanager/api/v2/files',
+    })
   }
 
-  getOne(id, cb) {
-    if (!id || typeof id === 'function') {
-      return cb(new Error('id parameter must be provided.'))
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/filemanager/api/v2/files/' + id,
-      },
-      cb,
-    )
+  getOne(id) {
+    return this.client._request({
+      method: 'GET',
+      path: '/filemanager/api/v2/files/' + id,
+    })
   }
 }
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -3,95 +3,68 @@ class List {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/lists',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/lists',
+      qs: options,
+    })
   }
 
-  getOne(id, cb) {
-    if (!id || typeof id === 'function') {
-      return cb(new Error('id parameter must be provided.'))
+  getOne(id) {
+    if (!id) {
+      return Promise.reject(new Error('id parameter must be provided.'))
     }
 
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/lists/' + id,
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/lists/' + id,
+    })
   }
 
-  getContacts(id, options, cb) {
-    if (!id || typeof id === 'function') {
-      return cb(new Error('id parameter must be provided.'))
+  getContacts(id, options) {
+    if (!id) {
+      return Promise.reject(new Error('id parameter must be provided.'))
     }
 
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/lists/' + id + '/contacts/all',
-        qs: options,
-        qsStringifyOptions: { indices: false },
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/lists/' + id + '/contacts/all',
+      qs: options,
+      qsStringifyOptions: { indices: false },
+    })
   }
 
-  getRecentContacts(id, options, cb) {
-    if (!id || typeof id === 'function') {
-      return cb(new Error('id parameter must be provided.'))
+  getRecentContacts(id, options) {
+    if (!id) {
+      return Promise.reject(new Error('id parameter must be provided.'))
     }
 
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/contacts/v1/lists/' + id + '/contacts/recent',
-        qs: options,
-        qsStringifyOptions: { indices: false },
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'GET',
+      path: '/contacts/v1/lists/' + id + '/contacts/recent',
+      qs: options,
+      qsStringifyOptions: { indices: false },
+    })
   }
 
-  addContacts(id, contactBody, cb) {
-    if (!id || typeof id === 'function') {
-      return cb(new Error('id parameter must be provided.'))
+  addContacts(id, contactBody) {
+    if (!id) {
+      return Promise.reject(new Error('id parameter must be provided.'))
     }
-    if (!contactBody || typeof contactBody === 'function') {
-      return cb(new Error('contactBody parameter must be provided.'))
+    if (!contactBody) {
+      return Promise.reject(
+        new Error('contactBody parameter must be provided.'),
+      )
     }
 
     var body = contactBody
 
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/contacts/v1/lists/' + id + '/add',
-        body: body,
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'POST',
+      path: '/contacts/v1/lists/' + id + '/add',
+      body,
+    })
   }
 }
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -15,7 +15,7 @@ class OAuth {
     return 'https://app.hubspot.com/oauth/authorize?' + qs.stringify(params)
   }
 
-  getAccessToken(data, cb) {
+  getAccessToken(data) {
     const form = {
       grant_type: 'authorization_code',
       client_id: this.client.clientId,
@@ -23,17 +23,14 @@ class OAuth {
       redirect_uri: this.client.redirectUri,
     }
     _.extend(form, data)
-    return this.client._request(
-      {
-        method: 'POST',
-        path: '/oauth/v1/token',
-        form,
-      },
-      cb,
-    )
+    return this.client._request({
+      method: 'POST',
+      path: '/oauth/v1/token',
+      form,
+    })
   }
 
-  refreshAccessToken(data, cb) {
+  refreshAccessToken(data) {
     const form = {
       grant_type: 'refresh_token',
       client_id: this.client.clientId,
@@ -50,14 +47,8 @@ class OAuth {
       })
       .then(results => {
         this.client.setAccessToken(results.access_token) // refresh the new access_token on the client
-        // cb(null, results)
         return results
       })
-    // callback not implemented/test
-    // .catch(err => {
-    //   cb(err)
-    //   throw err
-    // })
   }
 }
 

--- a/lib/owner.js
+++ b/lib/owner.js
@@ -3,20 +3,12 @@ class Owner {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/owners/v2/owners',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/owners/v2/owners',
+      qs: options,
+    })
   }
 }
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -3,20 +3,12 @@ class Page {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/content/api/v2/pages',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/content/api/v2/pages',
+      qs: options,
+    })
   }
 }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -3,20 +3,12 @@ class Pipeline {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/deals/v1/pipelines',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/deals/v1/pipelines',
+      qs: options,
+    })
   }
 }
 

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -3,20 +3,12 @@ class Subscription {
     this.client = client
   }
 
-  get(options, cb) {
-    if (typeof options === 'function') {
-      cb = options
-      options = {}
-    }
-
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/email/public/v1/subscriptions/timeline',
-        qs: options,
-      },
-      cb,
-    )
+  get(options) {
+    return this.client._request({
+      method: 'GET',
+      path: '/email/public/v1/subscriptions/timeline',
+      qs: options,
+    })
   }
 }
 

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -5,17 +5,17 @@ class Timeline {
     this.client = client
   }
 
-  createEventType(applicationId, userId, data, cb) {
+  createEventType(applicationId, userId, data) {
     data['applicationId'] = data['applicationId'] || applicationId
     const parameters = {
       method: 'POST',
       path: `/integrations/v1/${applicationId}/timeline/event-types?userId=${userId}`,
       body: data,
     }
-    return this.client._request(parameters, cb)
+    return this.client._request(parameters)
   }
 
-  updateEventType(applicationId, eventTypeId, data, cb) {
+  updateEventType(applicationId, eventTypeId, data) {
     data['applicationId'] = data['applicationId'] || applicationId
     const parameters = {
       method: 'PUT',
@@ -23,20 +23,20 @@ class Timeline {
       body: data,
     }
 
-    return this.client._request(parameters, cb)
+    return this.client._request(parameters)
   }
 
-  createEventTypeProperty(applicationId, eventTypeId, userId, data, cb) {
+  createEventTypeProperty(applicationId, eventTypeId, userId, data) {
     const parameters = {
       method: 'POST',
       path: `/integrations/v1/${applicationId}/timeline/event-types/${eventTypeId}/properties?userId=${userId}`,
       body: data,
     }
 
-    return this.client._request(parameters, cb)
+    return this.client._request(parameters)
   }
 
-  updateEventTypeProperty(applicationId, eventTypeId, propertyId, data, cb) {
+  updateEventTypeProperty(applicationId, eventTypeId, propertyId, data) {
     data['id'] = data['id'] || propertyId
     const parameters = {
       method: 'PUT',
@@ -44,10 +44,10 @@ class Timeline {
       body: data,
     }
 
-    return this.client._request(parameters, cb)
+    return this.client._request(parameters)
   }
 
-  createTimelineEvent(applicationId, eventTypeId, data, cb) {
+  createTimelineEvent(applicationId, eventTypeId, data) {
     if (!data.id) {
       data.id = guid()
     }
@@ -60,7 +60,7 @@ class Timeline {
       body: data,
     }
 
-    return this.client._request(parameters, cb)
+    return this.client._request(parameters)
   }
 }
 

--- a/lib/typescript/broadcast.ts
+++ b/lib/typescript/broadcast.ts
@@ -1,10 +1,7 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Broadcast {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 }
 
 export { Broadcast }

--- a/lib/typescript/campaign.ts
+++ b/lib/typescript/campaign.ts
@@ -1,17 +1,11 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Campaign {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 
   getOne(id: number, appId: number): RequestPromise
-  getOne(id: number, appId: number, cb: RequestCallback): void
 
   events(opts?: {}): RequestPromise
-  events(cb: RequestCallback): void
-  events(opts: {}, cb: RequestCallback): void
 }
 
 export { Campaign }

--- a/lib/typescript/company.ts
+++ b/lib/typescript/company.ts
@@ -1,55 +1,34 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 import { Properties } from './company_property'
 
 declare class Company {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 
   getById(id: number): RequestPromise
-  getById(id: number, cb: RequestCallback): void
 
   getRecentlyCreated(opts?: {}): RequestPromise
-  getRecentlyCreated(cb: RequestCallback): void
-  getRecentlyCreated(opts: {}, cb: RequestCallback): void
 
   getRecentlyModified(opts?: {}): RequestPromise
-  getRecentlyModified(cb: RequestCallback): void
-  getRecentlyModified(opts: {}, cb: RequestCallback): void
 
   getByDomain(domain: string): RequestPromise
-  getByDomain(domain: string, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   addContactToCompany(data: {
     companyId: number
     contactVid: number
   }): RequestPromise
-  addContactToCompany(
-    data: { companyId: number; contactVid: number },
-    cb: RequestCallback,
-  ): void
 
   getContactIds(id: number, opts?: {}): RequestPromise
-  getContactIds(id: number, cb: RequestCallback): void
-  getContactIds(id: number, opts: {}, cb: RequestCallback): void
 
   getContacts(id: number, opts?: {}): RequestPromise
-  getContacts(id: number, cb: RequestCallback): void
-  getContacts(id: number, opts: {}, cb: RequestCallback): void
 
   update(id: number, data: {}): RequestPromise
-  update(id: number, data: {}, cb: RequestCallback): void
 
   updateBatch(data: {}[]): RequestPromise
-  updateBatch(data: {}[], cb: RequestCallback): void
 
   delete(id: number): RequestPromise
-  delete(id: number, cb: RequestCallback): void
 
   properties: Properties
 }

--- a/lib/typescript/company_property.ts
+++ b/lib/typescript/company_property.ts
@@ -1,24 +1,17 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 import { Groups } from './company_property_group'
 
 declare class Properties {
   get(query?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(query: {}, cb: RequestCallback): void
 
   getByName(name: string): RequestPromise
-  getByName(name: string, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   update(name: string, data: {}): RequestPromise
-  update(name: string, data: {}, cb: RequestCallback): void
 
   upsert(name: string, data: {}): RequestPromise
-  // upsert(name: string, data: {}, cb: RequestCallback): void;
 
   groups: Groups
 }

--- a/lib/typescript/company_property_group.ts
+++ b/lib/typescript/company_property_group.ts
@@ -1,18 +1,13 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Groups {
   get(query?: {}): RequestPromise
-  get(query: {}, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   update(name: string, data: {}): RequestPromise
-  update(name: string, data: {}, cb: RequestCallback): void
 
   upsert(name: string, data: {}): RequestPromise
-  // upsert(name: string, data: {}, cb: RequestCallback): void;
 }
 
 export { Groups }

--- a/lib/typescript/contact.ts
+++ b/lib/typescript/contact.ts
@@ -1,52 +1,34 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 import { Properties } from './contact_property'
 
 declare class Contact {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 
   getByEmail(email: string): RequestPromise
-  getByEmail(email: string, cb: RequestCallback): void
 
   getByEmailBatch(email: string[]): RequestPromise
-  getByEmailBatch(email: string[], cb: RequestCallback): void
 
   getById(number: string): RequestPromise
-  getById(number: string, cb: RequestCallback): void
 
   getByIdBatch(ids: number[]): RequestPromise
-  getByIdBatch(ids: number[], cb: RequestCallback): void
 
   getByToken(utk: string): RequestPromise
-  getByToken(utk: string, cb: RequestCallback): void
 
   update(id: number, data: {}): RequestPromise
-  update(id: number, data: {}, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   createOrUpdateBatch(data: any[]): RequestPromise
-  createOrUpdateBatch(data: any[], cb: RequestCallback): void
 
   search(query: string): RequestPromise
-  search(query: string, cb: RequestCallback): void
 
   getRecentlyCreated(opts: {}): RequestPromise
-  getRecentlyCreated(cb: RequestCallback): void
-  getRecentlyCreated(opts: {}, cb: RequestCallback): void
 
   getRecentlyModified(opts: {}): RequestPromise
-  getRecentlyModified(cb: RequestCallback): void
-  getRecentlyModified(opts: {}, cb: RequestCallback): void
 
   createOrUpdate(email: string, data: any[]): RequestPromise
-  createOrUpdate(email: string, data: any[], cb: RequestCallback): void
 
   delete(id: number): RequestPromise
-  delete(id: number, cb: RequestCallback): void
 
   properties: Properties
 }

--- a/lib/typescript/contact_property.ts
+++ b/lib/typescript/contact_property.ts
@@ -1,36 +1,26 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Properties {
   get(): RequestPromise
-  get(cb: RequestCallback): void
 
   getByName(name: string): RequestPromise
-  getByName(name: string, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   update(name: string, data: {}): RequestPromise
-  update(name: string, data: {}, cb: RequestCallback): void
 
   upsert(name: string, data: {}): RequestPromise
-  // upsert(name: string, data: {}, cb: RequestCallback): void;
 
   getGroups(): RequestPromise
   getGroups(): RequestPromise
 
   createGroup(data: {}): void
-  createGroup(data: {}, cb: RequestCallback): void
 
   updateGroup(name: string, data: {}): void
-  updateGroup(name: string, data: {}, cb: RequestCallback): void
 
   deleteGroup(name: string): void
-  deleteGroup(name: string, cb: RequestCallback): void
 
   delete(name: string): void
-  delete(name: string, cb: RequestCallback): void
 }
 
 export { Properties }

--- a/lib/typescript/deal.ts
+++ b/lib/typescript/deal.ts
@@ -1,67 +1,33 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 import { Properties } from './deal_property'
 
 declare class Deal {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 
   getRecentlyCreated(opts?: {}): RequestPromise
-  getRecentlyCreated(cb: RequestCallback): void
-  getRecentlyCreated(opts: {}, cb: RequestCallback): void
 
   getRecentlyModified(opts?: {}): RequestPromise
-  getRecentlyModified(cb: RequestCallback): void
-  getRecentlyModified(opts: {}, cb: RequestCallback): void
 
   getById(id: number): RequestPromise
-  getById(id: number, cb: RequestCallback): void
 
   getAssociated(objectType: string, objectId: number, opts?: {}): RequestPromise
-  getAssociated(
-    objectType: string,
-    objectId: number,
-    cb: RequestCallback,
-  ): RequestPromise
-  getAssociated(
-    objectType: string,
-    objectId: number,
-    opts: {},
-    cb: RequestCallback,
-  ): RequestPromise
 
   deleteById(id: number): RequestPromise
-  deleteById(id: number, cb: RequestCallback): void
 
   updateById(id: number, data: {}): RequestPromise
-  updateById(id: number, data: {}, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   associate(
     id: number,
     objectType: string,
     associatedObjectId: number,
   ): RequestPromise
-  associate(
-    id: number,
-    objectType: string,
-    associatedObjectId: number,
-    cb: RequestCallback,
-  ): RequestPromise
 
   removeAssociation(
     id: number,
     objectType: string,
     associatedObjectId: number,
-  ): RequestPromise
-  removeAssociation(
-    id: number,
-    objectType: string,
-    associatedObjectId: number,
-    cb: RequestCallback,
   ): RequestPromise
 
   properties: Properties

--- a/lib/typescript/deal_property.ts
+++ b/lib/typescript/deal_property.ts
@@ -1,23 +1,16 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 import { Groups } from './deal_property_group'
 
 declare class Properties {
   get(query?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(query: {}, cb: RequestCallback): void
 
   getByName(name: string): RequestPromise
-  getByName(name: string, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   update(name: string, data: {}): RequestPromise
-  update(name: string, data: {}, cb: RequestCallback): void
 
   upsert(name: string, data: {}): RequestPromise
-  // upsert(name: string, data: {}, cb: RequestCallback): void;
 
   groups: Groups
 }

--- a/lib/typescript/deal_property_group.ts
+++ b/lib/typescript/deal_property_group.ts
@@ -1,18 +1,13 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Groups {
   get(query?: {}): RequestPromise
-  get(query: {}, cb: RequestCallback): void
 
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   update(name: string, data: {}): RequestPromise
-  update(name: string, data: {}, cb: RequestCallback): void
 
   upsert(name: string, data: {}): RequestPromise
-  // upsert(name: string, data: {}, cb: RequestCallback): void;
 }
 
 export { Groups }

--- a/lib/typescript/engagement.ts
+++ b/lib/typescript/engagement.ts
@@ -1,30 +1,13 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Engagement {
   create(data: {}): RequestPromise
-  create(data: {}, cb: RequestCallback): void
 
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 
   getRecentlyModified(opts?: {}): RequestPromise
-  getRecentlyModified(cb: RequestCallback): void
-  getRecentlyModified(opts: {}, cb: RequestCallback): void
 
   getAssociated(objectType: string, objectId: number, opts?: {}): RequestPromise
-  getAssociated(
-    objectType: string,
-    objectId: number,
-    cb: RequestCallback,
-  ): RequestPromise
-  getAssociated(
-    objectType: string,
-    objectId: number,
-    opts: {},
-    cb: RequestCallback,
-  ): RequestPromise
 }
 
 export { Engagement }

--- a/lib/typescript/file.ts
+++ b/lib/typescript/file.ts
@@ -1,13 +1,9 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class File {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 
   getOne(id: number): RequestPromise
-  getOne(id: number, cb: RequestCallback): void
 }
 
 export { File }

--- a/lib/typescript/list.ts
+++ b/lib/typescript/list.ts
@@ -1,24 +1,15 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class List {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 
   getOne(id: number): RequestPromise
-  getOne(id: number, cb: RequestCallback): void
 
   getContacts(id: number): RequestPromise
-  getContacts(id: number, cb: RequestCallback): void
-  getContacts(id: number, opts: {}, cb: RequestCallback): void
 
   getRecentContacts(id: number): RequestPromise
-  getRecentContacts(id: number, cb: RequestCallback): void
-  getRecentContacts(id: number, opts: {}, cb: RequestCallback): void
 
   addContacts(id: number, contactBody: {}): RequestPromise
-  addContacts(id: number, contactBody: {}, cb: RequestCallback): void
 }
 
 export { List }

--- a/lib/typescript/oauth.ts
+++ b/lib/typescript/oauth.ts
@@ -1,12 +1,9 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class OAuth {
   getAuthorizationUrl(opts?: {}): string
   getAccessToken(data: { code: string }): RequestPromise
-  getAccessToken(data: { code: string }, cb: RequestCallback): void
   refreshAccessToken(): RequestPromise
-  refreshAccessToken(cb: RequestCallback): void
 }
 
 export { OAuth }

--- a/lib/typescript/owner.ts
+++ b/lib/typescript/owner.ts
@@ -1,10 +1,7 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Owner {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 }
 
 export { Owner }

--- a/lib/typescript/page.ts
+++ b/lib/typescript/page.ts
@@ -1,10 +1,7 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Page {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 }
 
 export { Page }

--- a/lib/typescript/pipeline.ts
+++ b/lib/typescript/pipeline.ts
@@ -1,10 +1,7 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Pipeline {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 }
 
 export { Pipeline }

--- a/lib/typescript/subscription.ts
+++ b/lib/typescript/subscription.ts
@@ -1,10 +1,7 @@
-import { RequestCallback } from 'request'
 import { RequestPromise } from 'request-promise'
 
 declare class Subscription {
   get(opts?: {}): RequestPromise
-  get(cb: RequestCallback): void
-  get(opts: {}, cb: RequestCallback): void
 }
 
 export { Subscription }

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -3,54 +3,39 @@ class Workflow {
     this.client = client
   }
 
-  get(workflowId, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: `/automation/v3/workflows/${workflowId}`,
-      },
-      cb,
-    )
+  get(workflowId) {
+    return this.client._request({
+      method: 'GET',
+      path: `/automation/v3/workflows/${workflowId}`,
+    })
   }
 
-  getAll(cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: '/automation/v3/workflows',
-      },
-      cb,
-    )
+  getAll() {
+    return this.client._request({
+      method: 'GET',
+      path: '/automation/v3/workflows',
+    })
   }
 
-  enroll(workflowId, email, cb) {
-    return this.client._request(
-      {
-        method: 'POST',
-        path: `/automation/v2/workflows/${workflowId}/enrollments/contacts/${email}`,
-      },
-      cb,
-    )
+  enroll(workflowId, email) {
+    return this.client._request({
+      method: 'POST',
+      path: `/automation/v2/workflows/${workflowId}/enrollments/contacts/${email}`,
+    })
   }
 
-  unenroll(workflowId, email, cb) {
-    return this.client._request(
-      {
-        method: 'DELETE',
-        path: `/automation/v2/workflows/${workflowId}/enrollments/contacts/${email}`,
-      },
-      cb,
-    )
+  unenroll(workflowId, email) {
+    return this.client._request({
+      method: 'DELETE',
+      path: `/automation/v2/workflows/${workflowId}/enrollments/contacts/${email}`,
+    })
   }
 
-  current(contactId, cb) {
-    return this.client._request(
-      {
-        method: 'GET',
-        path: `/automation/v2/workflows/enrollments/contacts/${contactId}`,
-      },
-      cb,
-    )
+  current(contactId) {
+    return this.client._request({
+      method: 'GET',
+      path: `/automation/v2/workflows/enrollments/contacts/${contactId}`,
+    })
   }
 }
 

--- a/test/broadcasts.js
+++ b/test/broadcasts.js
@@ -20,18 +20,4 @@ describe('broadcasts', function() {
         .then(data => expect(data).to.be.a('array'))
     })
   })
-
-  describe('get with a callback', function() {
-    it('Should invoke the callback with the broadcasts', function() {
-      const hubspot = new Hubspot({
-        accessToken: process.env.ACCESS_TOKEN || 'fake-token',
-      })
-      let result
-      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
-
-      return hubspot.broadcasts
-        .get(fakeCallback)
-        .then(() => expect(result).to.be.a('array'))
-    })
-  })
 })

--- a/test/campaigns.js
+++ b/test/campaigns.js
@@ -21,15 +21,6 @@ describe('campaigns', function() {
           expect(data.campaigns).to.be.an('array')
         })
     })
-
-    it('Should invoke a callback', function() {
-      let result
-      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
-
-      return hubspot()
-        .campaigns.get(fakeCallback)
-        .then(() => expect(result.campaigns).to.be.a('array'))
-    })
   })
 
   describe('getOne', function() {
@@ -59,29 +50,9 @@ describe('campaigns', function() {
           expect(data.id).to.eq(campaignId)
         })
       })
-
-      it('Should take a callback as the second argument', function() {
-        let result
-        const fakeCallback = (_error, receivedValue) => (result = receivedValue)
-
-        return hubspotDemo.campaigns
-          .getOne(campaignId, fakeCallback)
-          .then(() => {
-            expect(result.id).to.eq(campaignId)
-          })
-      })
     })
 
     describe('unsuccessfully', function() {
-      it('Should error when passed a callback as the first argument', function() {
-        let result
-        const fakeCallback = error => (result = error)
-
-        return hubspotDemo.campaigns.getOne(fakeCallback).catch(() => {
-          expect(result.message).to.eq('id parameter must be provided.')
-        })
-      })
-
       it('Should error when not passed an id', function() {
         return hubspotDemo.campaigns.getOne().catch(error => {
           expect(error.message).to.eq('id parameter must be provided.')
@@ -104,15 +75,6 @@ describe('campaigns', function() {
           expect(data.campaigns).to.be.an('array')
         })
     })
-
-    it('Should invoke a callback', function() {
-      let result
-      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
-
-      return hubspot()
-        .campaigns.getById(fakeCallback)
-        .then(() => expect(result.campaigns).to.be.a('array'))
-    })
   })
 
   describe('events', function() {
@@ -128,15 +90,6 @@ describe('campaigns', function() {
         .then(data => {
           expect(data.events).to.be.an('array')
         })
-    })
-
-    it('Should invoke a callback', function() {
-      let result
-      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
-
-      return hubspot()
-        .campaigns.events(fakeCallback)
-        .then(() => expect(result.events).to.be.a('array'))
     })
   })
 })

--- a/test/owners.js
+++ b/test/owners.js
@@ -15,16 +15,4 @@ describe('Owners', function() {
       })
     })
   })
-
-  describe('get with a callback', function() {
-    it('Should invoke the callback with the owners', function() {
-      const hubspot = new Hubspot({ apiKey: 'demo' })
-      let result
-      const fakeCallback = (_error, receivedValue) => (result = receivedValue)
-
-      return hubspot.owners
-        .get(fakeCallback)
-        .then(() => expect(result).to.be.a('array'))
-    })
-  })
 })

--- a/test/typescript/hubspot.ts
+++ b/test/typescript/hubspot.ts
@@ -17,16 +17,7 @@ const handleError = (requestError: RequestError) => {
 
 const hubspot = new Hubspot(apiKeyOptions)
 
-// Promise
 hubspot.companies
   .get({ limit: 1 })
   .then(handleResponse)
   .catch(handleError)
-
-// Callback
-hubspot.companies.properties.groups.get((err: HubspotError, results) => {
-  if (err) {
-    console.error(err)
-  }
-  console.log(results)
-})


### PR DESCRIPTION
Why:

There is a lot of code we maintain to support callbacks. There is also
inconsistent support for usage throughout the codebase. Any users of the
library can achieve the same behavior as a callback by leveraging the
promises we return from api calls.

This PR:

Removes callback support.