### PR TITLE
Mock out deal tests

### DIFF
--- a/lib/deal.js
+++ b/lib/deal.js
@@ -65,7 +65,7 @@ class Deal {
   create(data) {
     return this.client._request({
       method: 'POST',
-      path: '/deals/v1/deal/',
+      path: '/deals/v1/deal',
       body: data,
     })
   }

--- a/test/deals.js
+++ b/test/deals.js
@@ -1,11 +1,73 @@
-const chai = require('chai')
-const expect = chai.expect
-
+const { expect } = require('chai')
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
 
-describe('Deals', function() {
+describe('deals', function() {
+  const hubspot = new Hubspot({
+    accessToken: process.env.ACCESS_TOKEN || 'fake-token',
+  })
+  const dealProperties = [
+    {
+      value: 'MadKudu',
+      name: 'dealname',
+    },
+    {
+      value: 'appointmentscheduled',
+      name: 'dealstage',
+    },
+    {
+      value: 'default',
+      name: 'pipeline',
+    },
+    {
+      value: Date.now(),
+      name: 'closedate',
+    },
+    {
+      value: '60000',
+      name: 'amount',
+    },
+    {
+      value: 'newbusiness',
+      name: 'dealtype',
+    },
+  ]
+  const companyProperties = [
+    { name: 'name', value: 'A company name' },
+    { name: 'description', value: 'A company description' },
+  ]
+  const createTestDeal = () =>
+    hubspot.deals.create({ properties: dealProperties })
+  const deleteTestDeal = dealId => hubspot.deals.deleteById(dealId)
+  const createTestCompany = () =>
+    hubspot.companies.create({ properties: companyProperties })
+  const createDealWithCompany = () =>
+    hubspot.companies
+      .create({ properties: companyProperties })
+      .then(companyData => {
+        return hubspot.deals
+          .create({
+            associations: {
+              associatedCompanyIds: [companyData.companyId],
+            },
+            properties: dealProperties,
+          })
+          .then(dealData => {
+            return {
+              dataCompanyId: companyData.companyId,
+              dataDealId: dealData.dealId,
+            }
+          })
+      })
+  const deleteTestCompany = companyId => hubspot.companies.delete(companyId)
+
   describe('get', function() {
+    const dealsEndpoint = {
+      path: '/deals/v1/deal/paged',
+      response: { deals: [] },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [dealsEndpoint] })
+
     it('Should return deal properties', function() {
       return hubspot.deals.get().then(data => {
         expect(data).to.be.a('object')
@@ -15,32 +77,58 @@ describe('Deals', function() {
   })
 
   describe('getRecentlyCreated', function() {
+    const recentlyCreatedDealsEndpoint = {
+      path: '/deals/v1/deal/recent/created',
+      response: { results: [] },
+    }
+    fakeHubspotApi.setupServer({
+      getEndpoints: [recentlyCreatedDealsEndpoint],
+    })
+
     it('Returns Recently Created Deals', function() {
       return hubspot.deals.getRecentlyCreated().then(data => {
-        // console.log(data)
         expect(data.results).to.be.an('array')
-        expect(data.hasMore).to.equal(true)
       })
     })
   })
 
   describe('getRecentlyModified', function() {
+    const recentlyModifiedDealsEndpoint = {
+      path: '/deals/v1/deal/recent/modified',
+      response: { results: [] },
+    }
+    fakeHubspotApi.setupServer({
+      getEndpoints: [recentlyModifiedDealsEndpoint],
+    })
+
     it('Returns Recently Modified Deals', function() {
       return hubspot.deals.getRecentlyModified().then(data => {
         expect(data.results).to.be.an('array')
-        expect(data.hasMore).to.equal(true)
       })
     })
   })
 
   describe('getById', function() {
-    let dealId
+    let dealId = 123
+    const dealEndpoint = {
+      path: `/deals/v1/deal/${dealId}`,
+      response: {},
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [dealEndpoint] })
 
     before(function() {
-      return hubspot.deals.get().then(data => {
-        dealId = data.deals[0].dealId
-      })
+      if (process.env.NOCK_OFF) {
+        return createTestDeal().then(data => {
+          dealId = data.dealId
+        })
+      }
     })
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return deleteTestDeal(dealId)
+      }
+    })
+
     it("Returns the entire deal, including all of it's properties", function() {
       return hubspot.deals.getById(dealId).then(data => {
         expect(data).to.be.an('object')
@@ -49,23 +137,51 @@ describe('Deals', function() {
   })
 
   describe('getAssociated', function() {
+    let dealId = 123
+    let companyId = 234
+    const associationType = 'COMPANY'
+    const associatedDealsEndpoint = {
+      path: `/deals/v1/deal/associated/${associationType}/${companyId}/paged`,
+      response: { deals: [{}] },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [associatedDealsEndpoint] })
+
+    before(function() {
+      if (process.env.NOCK_OFF) {
+        return createDealWithCompany().then(({ dataDealId, dataCompanyId }) => {
+          dealId = dataDealId
+          companyId = dataCompanyId
+        })
+      }
+    })
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return deleteTestDeal(dealId).then(() => deleteTestCompany(companyId))
+      }
+    })
+
     it('Returns the deals associated to the object', function() {
-      return hubspot.deals.getAssociated('CONTACT', 394455).then(data => {
-        expect(data).to.be.an('object')
-        expect(data.hasMore).to.equal(false)
-        expect(data.deals).to.be.an('array')
-        expect(data.deals).to.have.length(0)
-      })
+      return hubspot.deals
+        .getAssociated(associationType, companyId)
+        .then(data => {
+          expect(data).to.be.an('object')
+          expect(data.deals).to.have.length(1)
+        })
     })
   })
 
   describe('deleteById', function() {
-    let dealId
+    let dealId = 123
+    const deleteDealEndpoint = {
+      path: `/deals/v1/deal/${dealId}`,
+      statusCode: 204,
+    }
+    fakeHubspotApi.setupServer({ deleteEndpoints: [deleteDealEndpoint] })
 
     before(function() {
-      return hubspot.deals.get().then(data => {
-        dealId = data.deals[0].dealId
-      })
+      if (process.env.NOCK_OFF) {
+        return createTestDeal().then(data => (dealId = data.dealId))
+      }
     })
 
     it('should delete a deal by Id', function() {
@@ -76,15 +192,25 @@ describe('Deals', function() {
   })
 
   describe('updateById', function() {
-    let dealId
+    let dealId = 123
+    const updateDealEndpoint = {
+      path: `/deals/v1/deal/${dealId}`,
+      response: {},
+    }
+    fakeHubspotApi.setupServer({ putEndpoints: [updateDealEndpoint] })
 
     before(function() {
-      return hubspot.deals.get().then(data => {
-        dealId = data.deals[0].dealId
-      })
+      if (process.env.NOCK_OFF) {
+        return createTestDeal().then(data => (dealId = data.dealId))
+      }
+    })
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return deleteTestDeal(dealId)
+      }
     })
 
-    it('Returns the entire deal profile', function() {
+    it('updates the deal', function() {
       return hubspot.deals
         .updateById(dealId, {
           properties: [{ name: 'dealname', value: 'MadKudu' }],
@@ -96,18 +222,22 @@ describe('Deals', function() {
   })
 
   describe('create', function() {
+    let dealId
+    const createDealEndpoint = {
+      path: '/deals/v1/deal',
+      response: {},
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [createDealEndpoint] })
+
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return deleteTestDeal(dealId)
+      }
+    })
+
     it('Returns a 200 with the newly created Deal', function() {
       return hubspot.deals
         .create({
-          // 'associations': {
-          //   'associatedCompanyIds': [
-          //     8954037
-          //   ],
-          //   'associatedVids': [
-          //     27136
-          //   ]
-          // },
-          portalId: 62515,
           properties: [
             {
               value: 'MadKudu',
@@ -121,14 +251,6 @@ describe('Deals', function() {
               value: 'default',
               name: 'pipeline',
             },
-            // {
-            //   'value': '24',
-            //   'name': 'hubspot_owner_id'
-            // },
-            {
-              value: Date.now(),
-              name: 'closedate',
-            },
             {
               value: '60000',
               name: 'amount',
@@ -140,24 +262,83 @@ describe('Deals', function() {
           ],
         })
         .then(data => {
+          dealId = data.dealId
           expect(data).to.be.a('object')
         })
     })
   })
 
-  // describe('Associate', function () {
-  //   it('Returns a 204 response if successful.', function () {
-  //     return hubspot.deals.associate(1126609, 'CONTACT', 394455).then(data => {
-  //       expect(data).to.be.a('object')
-  //     })
-  //   })
-  // })
+  describe('associate', function() {
+    let dealId = 123
+    let companyId = 234
+    const associationType = 'COMPANY'
+    const associateDealEndpoint = {
+      path: `/deals/v1/deal/${dealId}/associations/${associationType}`,
+      query: { id: companyId },
+      statusCode: 204,
+    }
+    fakeHubspotApi.setupServer({ putEndpoints: [associateDealEndpoint] })
 
-  // describe('Remove Association', function () {
-  //   it('Returns a 200 response if successful.', function () {
-  //     return hubspot.deals.removeAssociation(1126609, 'CONTACT', 394455).then(data => {
-  //       expect(res.statusCode).to.equal(204)
-  //     })
-  //   })
-  // })
+    before(function() {
+      if (process.env.NOCK_OFF) {
+        return Promise.all([
+          createTestDeal().then(data => (dealId = data.dealId)),
+          createTestCompany().then(data => (companyId = data.companyId)),
+        ])
+      }
+    })
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return Promise.all([
+          deleteTestDeal(dealId),
+          deleteTestCompany(companyId),
+        ])
+      }
+    })
+
+    it('Returns a 204', function() {
+      return hubspot.deals
+        .associate(dealId, associationType, companyId)
+        .then(data => {
+          expect(data).to.be.an('undefined')
+        })
+    })
+  })
+
+  describe('removeAssociation', function() {
+    let dealId = 123
+    let companyId = 234
+    const associationType = 'COMPANY'
+    const unassociateDealEndpoint = {
+      path: `/deals/v1/deal/${dealId}/associations/${associationType}`,
+      query: { id: companyId },
+      statusCode: 204,
+    }
+    fakeHubspotApi.setupServer({ deleteEndpoints: [unassociateDealEndpoint] })
+
+    before(function() {
+      if (process.env.NOCK_OFF) {
+        return createDealWithCompany().then(({ dataDealId, dataCompanyId }) => {
+          dealId = dataDealId
+          companyId = dataCompanyId
+        })
+      }
+    })
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return Promise.all([
+          deleteTestDeal(dealId),
+          deleteTestCompany(companyId),
+        ])
+      }
+    })
+
+    it('Returns a 204', function() {
+      return hubspot.deals
+        .removeAssociation(dealId, associationType, companyId)
+        .then(data => {
+          expect(data).to.be.an('undefined')
+        })
+    })
+  })
 })


### PR DESCRIPTION
Why:

One of the deal tests intermittently failed in CI. We'd like to
eventually mock out all the test api calls to keep CI consistant.

This change addresses the need by:

Uses the fakeHubspotApi throughout the deal tests.