### PR TITLE
Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -434,7 +434,6 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": false,
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
@@ -1339,7 +1338,6 @@
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": false,
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "description": "A node wrapper for the HubSpot API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Why:

- Release new version as 2.0 (breaking)

This change addresses the need by:

- Bumping the version number to publish to npm
