### PR TITLE
Add test coverage for oauth

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,4 +1,3 @@
-const _ = require('lodash')
 const qs = require('querystring')
 
 class OAuth {
@@ -10,8 +9,8 @@ class OAuth {
     const params = {
       client_id: this.client.clientId,
       redirect_uri: this.client.redirectUri,
+      ...data,
     }
-    _.extend(params, data)
     return 'https://app.hubspot.com/oauth/authorize?' + qs.stringify(params)
   }
 
@@ -21,8 +20,8 @@ class OAuth {
       client_id: this.client.clientId,
       client_secret: this.client.clientSecret,
       redirect_uri: this.client.redirectUri,
+      ...data,
     }
-    _.extend(form, data)
     return this.client._request({
       method: 'POST',
       path: '/oauth/v1/token',
@@ -37,8 +36,8 @@ class OAuth {
       client_secret: this.client.clientSecret,
       redirect_uri: this.client.redirectUri,
       refresh_token: this.client.refreshToken,
+      ...data,
     }
-    _.extend(form, data)
     return this.client
       ._request({
         method: 'POST',

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1,7 +1,6 @@
-const chai = require('chai')
-const expect = chai.expect
-
+const { expect } = require('chai')
 const Hubspot = require('..')
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
 
 describe('oauth', function() {
   let hubspot
@@ -23,41 +22,80 @@ describe('oauth', function() {
     })
   })
 
-  describe('refreshAccessToken', function() {
-    it('should return (and refresh) an accessToken, given a refreshToken - constructor', function() {
-      const params = {
-        clientId: process.env.clientId,
-        clientSecret: process.env.clientSecret,
-        redirectUri: process.env.redirectUri,
-        refreshToken: process.env.refreshToken,
-      }
-      const hubspot = new Hubspot(params)
-      if (!process.env.refreshToken) {
-        return
-      } // hard to reproduce on CI. local testing only for now
-      return hubspot.oauth.refreshAccessToken().then(res => {
-        expect(res.refresh_token).to.equal(params.refreshToken)
-        expect(res).to.have.a.property('access_token')
-        expect(hubspot.auth.bearer).to.equal(res.access_token)
-      })
-    })
+  describe('getAccessToken', function() {
+    const code = 'a_fake_code'
+    const clientProperties = {
+      clientId: 'fake_client_id',
+      clientSecret: 'fake_client_secret',
+      redirectUri: 'some-redirect-uri',
+    }
+    const expectedResponse = {
+      refresh_token: 'a_fake_refresh_token',
+      access_token: 'a_fake_access_token',
+      expires_in: 21600,
+    }
+    const oauthTokenEndpoint = {
+      path: '/oauth/v1/token',
+      request: {
+        grant_type: 'authorization_code',
+        client_id: clientProperties.clientId,
+        client_secret: clientProperties.clientSecret,
+        redirect_uri: clientProperties.redirectUri,
+        code,
+      },
+      response: expectedResponse,
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [oauthTokenEndpoint] })
 
-    it('should return (and refresh) an accessToken, given a refreshToken - params', function() {
-      const hubspot = new Hubspot({ accessToken: process.env.accessToken })
-      if (!process.env.refreshToken) {
-        return
-      } // hard to reproduce on CI. local testing only for now
-      const params = {
-        client_id: process.env.clientId,
-        client_secret: process.env.clientSecret,
-        redirect_uri: process.env.redirectUri,
-        refresh_token: process.env.refreshToken,
-      }
-      return hubspot.oauth.refreshAccessToken(params).then(res => {
-        expect(res.refresh_token).to.equal(params.refresh_token)
-        expect(res).to.have.a.property('access_token')
-        expect(hubspot.auth.bearer).to.equal(res.access_token)
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should return a token from hubspot', function() {
+        hubspot = new Hubspot(clientProperties)
+
+        return hubspot.oauth.getAccessToken({ code }).then(data => {
+          expect(data).to.deep.equal(expectedResponse)
+        })
       })
-    })
+    }
+  })
+
+  describe('refreshAccessToken', function() {
+    const clientProperties = {
+      clientId: 'fake_client_id',
+      clientSecret: 'fake_client_secret',
+      redirectUri: 'some-redirect-uri',
+      refreshToken: 'a_fake_refresh_token',
+      accessToken: 'a_fake_access_token',
+    }
+    const expectedResponse = {
+      refresh_token: 'a_new_fake_refresh_token',
+      access_token: 'a_new_fake_access_token',
+      expires_in: 21600,
+    }
+    const oauthTokenEndpoint = {
+      path: '/oauth/v1/token',
+      request: {
+        grant_type: 'refresh_token',
+        client_id: clientProperties.clientId,
+        client_secret: clientProperties.clientSecret,
+        redirect_uri: clientProperties.redirectUri,
+        refresh_token: clientProperties.refreshToken,
+      },
+      response: expectedResponse,
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [oauthTokenEndpoint] })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should return a token from hubspot', function() {
+        hubspot = new Hubspot(clientProperties)
+
+        return hubspot.oauth.refreshAccessToken().then(data => {
+          expect(data).to.deep.equal(expectedResponse)
+        })
+      })
+    }
   })
 })


### PR DESCRIPTION
Why:

- We'd like to have test coverage to sanity check any changes that we
make to the library.

This change addresses the need by:

- Adding test coverage for getAccessToken and refreshAccessToken.

NOTE: Since oauth requires a server to do the handshake dance with
HubSpot these tests will not pass with NOCK_OFF=true. I'm not sure if we
should disable these tests in that case or come up with another
solution.

When writing these tests I wrote them without mocking but had to
hardcode client_id and client_secret then do half the oauth handshake to
get a valid code that I could then trade for a token.