### PR TITLE
Add create and delete to lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ hubspot.pipelines.get(opts)
 ```javascript
 hubspot.lists.get(opts)
 hubspot.lists.getOne(id)
+hubspot.lists.create(data)
+hubspot.lists.delete(id)
 hubspot.lists.getContacts(id, opts)
 hubspot.lists.getRecentContacts(id, opts)
 hubspot.lists.addContacts(id, contactBody)

--- a/lib/list.js
+++ b/lib/list.js
@@ -22,6 +22,21 @@ class List {
     })
   }
 
+  create(data) {
+    return this.client._request({
+      method: 'POST',
+      path: '/contacts/v1/lists',
+      body: data,
+    })
+  }
+
+  delete(listId) {
+    return this.client._request({
+      method: 'DELETE',
+      path: `/contacts/v1/lists/${listId}`,
+    })
+  }
+
   getContacts(id, options) {
     if (!id) {
       return Promise.reject(new Error('id parameter must be provided.'))

--- a/test/contacts.js
+++ b/test/contacts.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai')
 const fakeHubspotApi = require('./helpers/fake_hubspot_api')
+const { createTestContact, deleteTestContact } = require('./helpers/factories')
 
 const Hubspot = require('..')
 const emailsFromContacts = contacts =>
@@ -14,32 +15,6 @@ describe('contacts', function() {
   const hubspot = new Hubspot({
     accessToken: process.env.ACCESS_TOKEN || 'fake-token',
   })
-  const createTestContact = () =>
-    hubspot.contacts.create({
-      properties: [
-        {
-          property: 'email',
-          value: 'node-hubspot' + Date.now() + '@madkudu.com',
-        },
-        {
-          property: 'firstname',
-          value: 'Try',
-        },
-        {
-          property: 'lastname',
-          value: 'MadKudu',
-        },
-        {
-          property: 'website',
-          value: 'http://www.madkudu.com',
-        },
-        {
-          property: 'company',
-          value: 'MadKudu',
-        },
-      ],
-    })
-  const deleteTestContact = contactId => hubspot.contacts.delete(contactId)
 
   describe('get', function() {
     const count = 10
@@ -114,12 +89,12 @@ describe('contacts', function() {
 
     before(function() {
       if (process.env.NOCK_OFF) {
-        return createTestContact().then(data => (contactId = data.vid))
+        return createTestContact(hubspot).then(data => (contactId = data.vid))
       }
     })
     after(function() {
       if (process.env.NOCK_OFF) {
-        return deleteTestContact(contactId)
+        return deleteTestContact(hubspot, contactId)
       }
     })
 
@@ -400,7 +375,7 @@ describe('contacts', function() {
 
     before(function() {
       if (process.env.NOCK_OFF) {
-        return createTestContact().then(data => (contactId = data.vid))
+        return createTestContact(hubspot).then(data => (contactId = data.vid))
       }
     })
 

--- a/test/helpers/factories.js
+++ b/test/helpers/factories.js
@@ -1,0 +1,29 @@
+const createTestContact = hubspot =>
+  hubspot.contacts.create({
+    properties: [
+      {
+        property: 'email',
+        value: 'node-hubspot' + Date.now() + '@madkudu.com',
+      },
+      {
+        property: 'firstname',
+        value: 'Try',
+      },
+      {
+        property: 'lastname',
+        value: 'MadKudu',
+      },
+      {
+        property: 'website',
+        value: 'http://www.madkudu.com',
+      },
+      {
+        property: 'company',
+        value: 'MadKudu',
+      },
+    ],
+  })
+const deleteTestContact = (hubspot, contactId) =>
+  hubspot.contacts.delete(contactId)
+
+module.exports = { createTestContact, deleteTestContact }

--- a/test/lists.js
+++ b/test/lists.js
@@ -1,12 +1,24 @@
-const chai = require('chai')
-const expect = chai.expect
-
+const { expect } = require('chai')
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
+const { createTestContact, deleteTestContact } = require('./helpers/factories')
 
-describe('Lists', function() {
-  describe('Get Lists', function() {
-    it('Should return contact lists', function() {
+describe('lists', function() {
+  const hubspot = new Hubspot({
+    accessToken: process.env.ACCESS_TOKEN || 'some-fake-token',
+  })
+  const listProperties = { name: 'Test list name' }
+  const createTestList = () => hubspot.lists.create(listProperties)
+  const deleteTestList = listId => hubspot.lists.delete(listId)
+
+  describe('get', function() {
+    const listsEndpoint = {
+      path: '/contacts/v1/lists',
+      response: { lists: [] },
+    }
+    fakeHubspotApi.setupServer({ getEndpoints: [listsEndpoint] })
+
+    it('should return contact lists', function() {
       return hubspot.lists.get().then(data => {
         expect(data).to.be.a('object')
         expect(data.lists).to.be.a('array')
@@ -14,59 +26,247 @@ describe('Lists', function() {
     })
   })
 
-  describe('Get List by Id', function() {
-    it('Should return one contact in a list', function() {
-      return hubspot.lists.getOne(1).then(data => {
-        expect(data).to.be.a('object')
-        expect(data).to.have.a.property('name')
+  describe('getOne', function() {
+    describe('when passed a listId', function() {
+      let listId = 123
+      const listEndpoint = {
+        path: `/contacts/v1/lists/${listId}`,
+        response: listProperties,
+      }
+      fakeHubspotApi.setupServer({ getEndpoints: [listEndpoint] })
+
+      before(function() {
+        if (process.env.NOCK_OFF) {
+          return createTestList(listProperties).then(
+            data => (listId = data.listId),
+          )
+        }
+      })
+      after(function() {
+        if (process.env.NOCK_OFF) {
+          return deleteTestList(listId)
+        }
+      })
+
+      it('should return one contact list', function() {
+        return hubspot.lists.getOne(listId).then(data => {
+          expect(data).to.be.a('object')
+          expect(data.name).to.equal(listProperties.name)
+        })
+      })
+    })
+
+    describe('when not passed a listId', function() {
+      it('should return a rejected promise', function() {
+        return hubspot.lists
+          .getOne()
+          .then(data => {
+            throw new Error('I should have thrown an error')
+          })
+          .catch(error => {
+            expect(error.message).to.equal('id parameter must be provided.')
+          })
       })
     })
   })
 
-  describe('Get Contacts In A List', function() {
+  describe('create', function() {
     let listId
+    const createListEndpoint = {
+      path: '/contacts/v1/lists',
+      request: listProperties,
+      response: listProperties,
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [createListEndpoint] })
 
-    // obtain a valid listID
-    before(function() {
-      return hubspot.lists.get().then(data => {
-        listId = data.lists[0].listId
-      })
+    after(function() {
+      if (process.env.NOCK_OFF) {
+        return deleteTestList(listId)
+      }
     })
 
-    it('Should return all contacts in a list', function() {
-      return hubspot.lists.getContacts(listId).then(data => {
+    it('should return the created list', function() {
+      return hubspot.lists.create(listProperties).then(data => {
+        listId = data.listId
         expect(data).to.be.a('object')
-        expect(data.contacts).to.be.a('array')
       })
     })
   })
 
-  describe('Get recently updated and created contacts', function() {
+  describe('delete', function() {
     let listId
+    const deleteListEndpoint = {
+      path: `/contacts/v1/lists/${listId}`,
+      statusCode: 204,
+    }
+    fakeHubspotApi.setupServer({ deleteEndpoints: [deleteListEndpoint] })
 
-    // obtain a valid listID
     before(function() {
-      return hubspot.lists.get().then(data => {
-        listId = data.lists[0].listId
-      })
+      if (process.env.NOCK_OFF) {
+        return createTestList(listProperties).then(
+          data => (listId = data.listId),
+        )
+      }
     })
 
-    it('Should a list of recently_updated contacts', function() {
-      return hubspot.lists.getRecentContacts(listId).then(data => {
-        expect(data).to.be.a('object')
-        expect(data.contacts).to.be.a('array')
+    it('should return a 204', function() {
+      return hubspot.lists.delete(listId).then(data => {
+        expect(data).to.be.an('undefined')
       })
     })
   })
 
-  describe('Add existing contacts to a list', function() {
-    //   it('Should add contact to a list of contacts', function () {
-    //     return hubspot.lists.addContacts(5, {
-    //       'vids': [61571], 'emails': ['testingapis@hubspot.com']
-    //     }).then(data => {
-    //       expect(data).to.be.a('object')
-    //       expect(data.updated).to.be.a('array')
-    //     })
-    //   })
+  describe('getContacts', function() {
+    describe('when passed a listId', function() {
+      let listId = 123
+      const listContactsEndpoint = {
+        path: `/contacts/v1/lists/${listId}/contacts/all`,
+        response: { contacts: [] },
+      }
+      fakeHubspotApi.setupServer({ getEndpoints: [listContactsEndpoint] })
+
+      before(function() {
+        if (process.env.NOCK_OFF) {
+          return createTestList(listProperties).then(
+            data => (listId = data.listId),
+          )
+        }
+      })
+      after(function() {
+        if (process.env.NOCK_OFF) {
+          return deleteTestList(listId)
+        }
+      })
+
+      it('should return contacts', function() {
+        return hubspot.lists.getContacts(listId).then(data => {
+          expect(data).to.be.a('object')
+          expect(data.contacts).to.be.an('array')
+        })
+      })
+    })
+
+    describe('when not passed a listId', function() {
+      it('should return a rejected promise', function() {
+        return hubspot.lists
+          .getContacts()
+          .then(data => {
+            throw new Error('I should have thrown an error')
+          })
+          .catch(error => {
+            expect(error.message).to.equal('id parameter must be provided.')
+          })
+      })
+    })
+  })
+
+  describe('getRecentContacts', function() {
+    describe('when passed a listId', function() {
+      let listId = 123
+      const listContactsEndpoint = {
+        path: `/contacts/v1/lists/${listId}/contacts/recent`,
+        response: { contacts: [] },
+      }
+      fakeHubspotApi.setupServer({ getEndpoints: [listContactsEndpoint] })
+
+      before(function() {
+        if (process.env.NOCK_OFF) {
+          return createTestList(listProperties).then(
+            data => (listId = data.listId),
+          )
+        }
+      })
+      after(function() {
+        if (process.env.NOCK_OFF) {
+          return deleteTestList(listId)
+        }
+      })
+
+      it('should return contacts', function() {
+        return hubspot.lists.getRecentContacts(listId).then(data => {
+          expect(data).to.be.a('object')
+          expect(data.contacts).to.be.an('array')
+        })
+      })
+    })
+
+    describe('when not passed a listId', function() {
+      it('should return a rejected promise', function() {
+        return hubspot.lists
+          .getRecentContacts()
+          .then(data => {
+            throw new Error('I should have thrown an error')
+          })
+          .catch(error => {
+            expect(error.message).to.equal('id parameter must be provided.')
+          })
+      })
+    })
+  })
+
+  describe('addContacts', function() {
+    describe('when a id and contactBody is provided', function() {
+      let listId = 123
+      let contactId = 234
+      const addContactToListEndpoint = {
+        path: `/contacts/v1/lists/${listId}/add`,
+        request: { vids: [contactId] },
+        response: { contacts: [] },
+      }
+      fakeHubspotApi.setupServer({ postEndpoints: [addContactToListEndpoint] })
+
+      before(function() {
+        if (process.env.NOCK_OFF) {
+          return Promise.all([
+            createTestContact(hubspot).then(data => (contactId = data.vid)),
+            createTestList(listProperties).then(data => (listId = data.listId)),
+          ])
+        }
+      })
+      after(function() {
+        if (process.env.NOCK_OFF) {
+          return Promise.all([
+            deleteTestContact(hubspot, contactId),
+            deleteTestList(listId),
+          ])
+        }
+      })
+
+      it('should return results', function() {
+        return hubspot.lists
+          .addContacts(listId, { vids: [contactId] })
+          .then(data => {
+            expect(data).to.be.a('object')
+          })
+      })
+    })
+
+    describe('when not passed a listId', function() {
+      it('should return a rejected promise', function() {
+        return hubspot.lists
+          .addContacts()
+          .then(data => {
+            throw new Error('I should have thrown an error')
+          })
+          .catch(error => {
+            expect(error.message).to.equal('id parameter must be provided.')
+          })
+      })
+    })
+
+    describe('when passed a listId but not contactBody', function() {
+      it('should return a rejected promise', function() {
+        return hubspot.lists
+          .addContacts(123)
+          .then(data => {
+            throw new Error('I should have thrown an error')
+          })
+          .catch(error => {
+            expect(error.message).to.equal(
+              'contactBody parameter must be provided.',
+            )
+          })
+      })
+    })
   })
 })


### PR DESCRIPTION
Why:

Some users may wish to create and delete contact lists through the api.

This PR:

Adds the create and delete methods to list and increases test coverage.