### PR TITLE
Move the Contributing section to it's own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,17 +383,7 @@ MIT
 
 ## Contributing
 
-Before submitting a pull request, please make sure the following is done:
-
-1. Fork the repository and create your branch from master.
-1. Run `npm build`. This will:
-   a. Run `npm install` in the repository root.
-   a. Ensure the test suite passes with`npm test`.
-   a. Format your code with prettier and eslint using `npm run lint`.
-
-1. If you’ve fixed a bug or added code that should be tested, add tests!
-
-Tip: `npm run mocha -- --grep "test name"` is helpful in development.
+See our [contributing guidelines](/contributing.md)
 
 ## Development Workflow
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,13 @@
+## Contributing
+
+Before submitting a pull request, please make sure the following is done:
+
+1. Fork the repository and create your branch from master.
+1. Run `npm build`. This will:
+   a. Run `npm install` in the repository root.
+   a. Ensure the test suite passes with`npm test`.
+   a. Format your code with prettier and eslint using `npm run lint`.
+
+1. If you’ve fixed a bug or added code that should be tested, add tests!
+
+Tip: `npm run mocha -- --grep "test name"` is helpful in development.


### PR DESCRIPTION
Why:

Github has some built in features if you have a contributing.md file.

This PR:

Moves the contributing section of the readme to it's own file and links
to it.