### PR TITLE
Add option to ignore limit check, use headers for limit check

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.codeclimate.yml
+.editorconfig
+.env.template
+.eslintrc.js
+.prettierrc
+.travis.yml

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,4 +3,5 @@
   "semi": false,
   "printWidth": 80,
   "trailingComma": "all",
+  "endOfLine": "crlf"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,6 @@
   "singleQuote": true,
   "semi": false,
   "printWidth": 80,
-  "trailingComma": "all",
+  "trailingComma": "es5",
   "endOfLine": "crlf"
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ npm install hubspot
 
 ```javascript
 const Hubspot = require('hubspot')
-const hubspot = new Hubspot({ apiKey: 'abc' })
+const hubspot = new Hubspot({ 
+  apiKey: 'abc',
+  checkLimit: false // (Optional) Specify whether or not to check the API limit on each call. Default: true 
+})
 ```
 
 You can also authenticate via token:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can also authenticate via token:
 const hubspot = new Hubspot({ accessToken: 'abc' })
 ```
 
-To change the base url
+To change the base url:
 
 ```javascript
 const hubspot = new Hubspot({ accessToken: 'abc', baseUrl: 'https://some-url' })
@@ -75,16 +75,15 @@ hubspot.contacts
 ## {EXAMPLE} Create Contact
 
 ```javascript
-const contactObject = {
-            "properties":
-            [
-                { "property": "firstname","value": yourvalue },
-                { "property": "lastname", "value": yourvalue }
-            ]
-        };
+const contactObj = {
+  "properties": [
+    { "property": "firstname","value": yourvalue },
+    { "property": "lastname", "value": yourvalue }
+  ]
+};
 
-          const hubspot = new Hubspot({ apiKey: YOUR API KEY });
-          const hubspotContact = await hubspot.contacts.create(contactObj);
+const hubspot = new Hubspot({ apiKey: YOUR_API_KEY });
+const hubspotContact = await hubspot.contacts.create(contactObj);
 ```
 
 ## {EXAMPLE} If you need to insert multiple values
@@ -372,9 +371,9 @@ return hubspot.oauth.getAccessToken(params).then(...)
 
 You may use this library in your Typescript project via:
 
-```
+```typescript
 import Hubspot from 'hubspot';
-const hubspot = new Hubspot({ apiKey: 'key' });
+const hubspot = new Hubspot({ apiKey: YOUR_API_KEY });
 ```
 
 ## License

--- a/contributing.md
+++ b/contributing.md
@@ -5,7 +5,7 @@ Before submitting a pull request, please make sure the following is done:
 1. Fork the repository and create your branch from master.
 2. Run `npm build`. This will:
     1. Run `npm install` in the repository root.
-    2. Ensure the test suite passes with`npm test`.
+    2. Ensure the test suite passes with `npm test`.
     3. Format your code with prettier and eslint using `npm run lint`.
 3. If you’ve fixed a bug or added code that should be tested, add tests!
 

--- a/contributing.md
+++ b/contributing.md
@@ -3,11 +3,10 @@
 Before submitting a pull request, please make sure the following is done:
 
 1. Fork the repository and create your branch from master.
-1. Run `npm build`. This will:
-   a. Run `npm install` in the repository root.
-   a. Ensure the test suite passes with`npm test`.
-   a. Format your code with prettier and eslint using `npm run lint`.
-
-1. If you’ve fixed a bug or added code that should be tested, add tests!
+2. Run `npm build`. This will:
+    1. Run `npm install` in the repository root.
+    2. Ensure the test suite passes with`npm test`.
+    3. Format your code with prettier and eslint using `npm run lint`.
+3. If you’ve fixed a bug or added code that should be tested, add tests!
 
 Tip: `npm run mocha -- --grep "test name"` is helpful in development.

--- a/lib/client.js
+++ b/lib/client.js
@@ -110,6 +110,7 @@ class Client extends EventEmitter {
       params.auth = this.auth
     }
     params.json = true
+    params.resolveWithFullResponse = true
 
     params.url = this.baseUrl + params.path
     delete params.path
@@ -123,38 +124,56 @@ class Client extends EventEmitter {
 
     return this.checkApiLimit(params).then(() => {
       this.emit('apiCall', params)
-      return limiter.schedule(() => request(params)) // limit the number of concurrent requests
+      return limiter.schedule(() =>
+        request(params)
+          .then(res => {
+            this.updateApiLimit(res)
+            return res
+          })
+          .then(res => res.body),
+      ) // limit the number of concurrent requests
     })
   }
 
+  updateApiLimit(res) {
+    const { headers } = res
+    if (this.usageLimit === undefined) {
+      this.usageLimit = headers['x-hubspot-ratelimit-daily']
+    }
+    this.currentUsage = headers['x-hubspot-ratelimit-daily-remaining']
+    return Promise.resolve()
+  }
+
   checkApiLimit(params) {
-    if (this.auth) {
-      // don't check the api limit for the api call
-      return Promise.resolve()
-    }
-    if (/integrations\/v1\/limit|oauth/.test(params.url)) {
-      // don't check the api limit for the api call
-      return Promise.resolve()
-    }
-    if (!this.checkLimit) {
-      // don't check the api limit for the api call
-      return Promise.resolve()
-    }
-    if (this.maxUsePercent === 0) {
-      // if maxUsePercent set to 0, do not check for the API limit (use at your own risk)
-      return Promise.resolve()
-    }
-    return this.getApiLimit().then(results => {
-      const { usageLimit = 40000, currentUsage = 0 } = results
-      const usagePercent = (100.0 * currentUsage) / usageLimit
-      debug('usagePercent', usagePercent, 'apiCalls', this.apiCalls)
-      if (usagePercent > this.maxUsePercent) {
-        const err = new Error('Too close to the API limit')
-        err.usageLimit = usageLimit
-        err.currentUsage = currentUsage
-        err.usagePercent = usagePercent
-        throw err
+    return new Promise((resolve, reject) => {
+      if (this.auth) {
+        // don't check the api limit for the api call
+        resolve()
       }
+      if (/integrations\/v1\/limit|oauth/.test(params.url)) {
+        // don't check the api limit for the api call
+        resolve()
+      }
+      if (!this.checkLimit) {
+        // don't check the api limit for the api call
+        resolve()
+      }
+      if (this.maxUsePercent === 0) {
+        // if maxUsePercent set to 0, do not check for the API limit (use at your own risk)
+        resolve()
+      }
+      if (this.currentUsage !== undefined) {
+        const usagePercent = (100.0 * this.currentUsage) / this.usageLimit
+        debug('usagePercent', usagePercent, 'apiCalls', this.apiCalls)
+        if (usagePercent > this.maxUsePercent) {
+          const err = new Error('Too close to the API limit')
+          err.usageLimit = this.usageLimit
+          err.currentUsage = this.currentUsage
+          err.usagePercent = usagePercent
+          reject(err)
+        }
+      }
+      resolve()
     })
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -140,7 +140,10 @@ class Client extends EventEmitter {
     if (this.usageLimit === undefined) {
       this.usageLimit = headers['x-hubspot-ratelimit-daily']
     }
-    this.currentUsage = headers['x-hubspot-ratelimit-daily-remaining']
+    if (this.usageLimit !== undefined) {
+      this.currentUsage =
+        this.usageLimit - headers['x-hubspot-ratelimit-daily-remaining']
+    }
     return Promise.resolve()
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,7 @@ const EventEmitter = require('events').EventEmitter
 const Bottleneck = require('bottleneck')
 const limiter = new Bottleneck({
   maxConcurrent: 9,
-  minTime: 1000,
+  minTime: 1000 / 8,
 })
 
 const debug = require('debug')('hubspot:client')
@@ -130,7 +130,7 @@ class Client extends EventEmitter {
             this.updateApiLimit(res)
             return res
           })
-          .then(res => res.body),
+          .then(res => res.body)
       ) // limit the number of concurrent requests
     })
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -47,6 +47,8 @@ class Client extends EventEmitter {
       debug('apiCall', _.pick(params, ['method', 'url']))
       this.apiCalls += 1
     })
+    this.checkLimit =
+      options.checkLimit !== undefined ? options.checkLimit : true
 
     this.broadcasts = new Broadcast(this)
     this.campaigns = new Campaign(this)
@@ -131,6 +133,10 @@ class Client extends EventEmitter {
       return Promise.resolve()
     }
     if (/integrations\/v1\/limit|oauth/.test(params.url)) {
+      // don't check the api limit for the api call
+      return Promise.resolve()
+    }
+    if (!this.checkLimit) {
       // don't check the api limit for the api call
       return Promise.resolve()
     }

--- a/lib/company.js
+++ b/lib/company.js
@@ -85,7 +85,7 @@ class Company {
   addContactToCompany(data) {
     if (!data || !data.companyId || !data.contactVid) {
       return Promise.reject(
-        new Error('companyId and contactVid params must be provided'),
+        new Error('companyId and contactVid params must be provided')
       )
     }
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -69,7 +69,7 @@ class List {
     }
     if (!contactBody) {
       return Promise.reject(
-        new Error('contactBody parameter must be provided.'),
+        new Error('contactBody parameter must be provided.')
       )
     }
 

--- a/lib/typescript/deal.ts
+++ b/lib/typescript/deal.ts
@@ -21,13 +21,13 @@ declare class Deal {
   associate(
     id: number,
     objectType: string,
-    associatedObjectId: number,
+    associatedObjectId: number
   ): RequestPromise
 
   removeAssociation(
     id: number,
     objectType: string,
-    associatedObjectId: number,
+    associatedObjectId: number
   ): RequestPromise
 
   properties: Properties

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,7 @@
     },
     "co": {
       "version": "4.6.0",
+      "resolved": false,
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
@@ -481,6 +482,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1265,6 +1276,12 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1338,6 +1355,7 @@
     },
     "json-schema-traverse": {
       "version": "0.3.1",
+      "resolved": false,
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "main": "index.js",
   "scripts": {
     "build": "npm install && npm test && npm run lint",
-    "test": "NODE_ENV=test npm run lint && npm run mocha && npm run tsc",
+    "test": "cross-env NODE_ENV=test npm run lint && npm run mocha && npm run tsc",
     "coverage": "nyc --reporter=lcov mocha --timeout=10000",
     "lint": "npm run prettier && npm run eslint",
     "tsc": "tsc",
     "ts-node": "ts-node test/typescript/hubspot.ts",
-    "mocha": "./node_modules/mocha/bin/mocha --recursive test/ --timeout 15000",
-    "eslint": "./node_modules/eslint/bin/eslint.js . --fix",
-    "prettier": "./node_modules/prettier/bin-prettier.js --write '{lib,test}/**/*.{j,t}s'",
-    "watch-test": "./node_modules/mocha/bin/mocha --recursive test/ --timeout 15000 --watch"
+    "mocha": "mocha --recursive test/ --timeout 15000",
+    "eslint": "eslint . --fix",
+    "prettier": "prettier --write {lib,test}/**/*.{js,ts}",
+    "watch-test": "mocha --recursive test/ --timeout 15000 --watch"
   },
   "repository": {
     "type": "git",
@@ -39,6 +39,7 @@
     "@types/request": "^2.47.0",
     "@types/request-promise": "^4.1.41",
     "chai": "^4.1.2",
+    "cross-env": "^5.2.0",
     "dotenv": "^6.2.0",
     "eslint": "^5.7.0",
     "eslint-config-prettier": "^3.3.0",

--- a/test/contact_properties.js
+++ b/test/contact_properties.js
@@ -183,7 +183,7 @@ describe('contacts.properties', function() {
           .upsert(contactPropertyProperties)
           .then(data => {
             expect(data.description).to.eq(
-              contactPropertyProperties.description,
+              contactPropertyProperties.description
             )
           })
       })

--- a/test/contacts.js
+++ b/test/contacts.js
@@ -7,8 +7,8 @@ const emailsFromContacts = contacts =>
   contacts.flatMap(contact =>
     contact['identity-profiles'].map(
       profile =>
-        profile.identities.find(identity => identity.type === 'EMAIL').value,
-    ),
+        profile.identities.find(identity => identity.type === 'EMAIL').value
+    )
   )
 
 describe('contacts', function() {

--- a/test/lists.js
+++ b/test/lists.js
@@ -38,7 +38,7 @@ describe('lists', function() {
       before(function() {
         if (process.env.NOCK_OFF) {
           return createTestList(listProperties).then(
-            data => (listId = data.listId),
+            data => (listId = data.listId)
           )
         }
       })
@@ -104,7 +104,7 @@ describe('lists', function() {
     before(function() {
       if (process.env.NOCK_OFF) {
         return createTestList(listProperties).then(
-          data => (listId = data.listId),
+          data => (listId = data.listId)
         )
       }
     })
@@ -128,7 +128,7 @@ describe('lists', function() {
       before(function() {
         if (process.env.NOCK_OFF) {
           return createTestList(listProperties).then(
-            data => (listId = data.listId),
+            data => (listId = data.listId)
           )
         }
       })
@@ -172,7 +172,7 @@ describe('lists', function() {
       before(function() {
         if (process.env.NOCK_OFF) {
           return createTestList(listProperties).then(
-            data => (listId = data.listId),
+            data => (listId = data.listId)
           )
         }
       })
@@ -263,7 +263,7 @@ describe('lists', function() {
           })
           .catch(error => {
             expect(error.message).to.equal(
-              'contactBody parameter must be provided.',
+              'contactBody parameter must be provided.'
             )
           })
       })

--- a/test/timeline.js
+++ b/test/timeline.js
@@ -28,7 +28,7 @@ describe('timeline', function() {
         name: 'NumericProperty',
         label: 'Numeric Property',
         propertyType: 'Numeric',
-      },
+      }
     )
 
   describe('createEventType', () => {
@@ -145,7 +145,7 @@ describe('timeline', function() {
         return createEventType().then(data => {
           eventTypeId = data.id
           return createEventTypeProperty(eventTypeId).then(
-            data => (eventTypePropertyId = data.id),
+            data => (eventTypePropertyId = data.id)
           )
         })
       }
@@ -161,7 +161,7 @@ describe('timeline', function() {
             name: 'NumericProperty',
             label: 'A new label',
             propertyType: 'Numeric',
-          },
+          }
         )
         .then(data => {
           expect(data.label).to.eq('A new label')

--- a/test/workflows.js
+++ b/test/workflows.js
@@ -14,7 +14,7 @@ describe('workflows', function() {
       const firstContact = data.contacts[0]
       contactId = firstContact.vid
       contactEmail = firstContact['identity-profiles'][0].identities.find(
-        obj => obj.type === 'EMAIL',
+        obj => obj.type === 'EMAIL'
       ).value
     })
   })


### PR DESCRIPTION
# Why

Currently uses up 2 API calls for each call. This adds a simple option to the constructor to ignore it:

```javascript
const Hubspot = require('hubspot');
const hubspot = new Hubspot({
    apiKey: 'key',
    checkLimit: false // Ignores API limit check
});
```

A more elegant solution needs to be put in place for rate limit checking (something involving the [API response headers](https://developers.hubspot.com/docs/faq/working-within-the-hubspot-api-rate-limits)), so this will be removed in the future.

This change addresses the need by:

- Relates to #51 

Also

- fixed npm scripts and prettier/editorconfig settings to work cross env 
- and corrected some style issues in contributing.md and README.md.
