### PR TITLE
Added option to override rate limiter config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
-node_js: ["8.9.*"]
+node_js:
+- "node"
+- 10
+- 8
+- 6
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ const hubspot = new Hubspot({
 You can also authenticate via token:
 
 ```javascript
-const hubspot = new Hubspot({ accessToken: 'abc' })
+const hubspot = new Hubspot({ accessToken: YOUR_ACCESS_TOKEN })
 ```
 
 To change the base url:
 
 ```javascript
-const hubspot = new Hubspot({ accessToken: 'abc', baseUrl: 'https://some-url' })
+const hubspot = new Hubspot({ accessToken: YOUR_ACCESS_TOKEN, baseUrl: 'https://some-url' })
 ```
 
 If you're an app developer, you can also instantiate a client with your app
@@ -55,6 +55,20 @@ return hubspot.refreshAccessToken()
     console.log(hubspot.accessToken)
     return hubspot.contacts.get()
   })
+```
+
+### Changing rate limiter options
+
+[Bottleneck](https://github.com/SGrondin/bottleneck) is used for rate limiting. To override the default settings, pass a `limiter` object when instantiating the client. Bottleneck options can be found [here](https://github.com/SGrondin/bottleneck#constructor).
+
+```javascript
+const hubspot = new Hubspot({
+  apiKey: YOUR_API_KEY,
+  limiter: {
+    maxConcurrent: 2,
+    minTime: 1000 / 9,
+  }
+})
 ```
 
 ## Usage

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,10 +18,6 @@ const _ = require('lodash')
 const request = require('request-promise')
 const EventEmitter = require('events').EventEmitter
 const Bottleneck = require('bottleneck')
-const limiter = new Bottleneck({
-  maxConcurrent: 9,
-  minTime: 1000 / 8,
-})
 
 const debug = require('debug')('hubspot:client')
 
@@ -49,6 +45,10 @@ class Client extends EventEmitter {
     })
     this.checkLimit =
       options.checkLimit !== undefined ? options.checkLimit : true
+    this.limiter = new Bottleneck(Object.assign({
+      maxConcurrent: 2,
+      minTime: 1000 / 9,
+    }, options.limiter))
 
     this.broadcasts = new Broadcast(this)
     this.campaigns = new Campaign(this)

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,10 +45,15 @@ class Client extends EventEmitter {
     })
     this.checkLimit =
       options.checkLimit !== undefined ? options.checkLimit : true
-    this.limiter = new Bottleneck(Object.assign({
-      maxConcurrent: 2,
-      minTime: 1000 / 9,
-    }, options.limiter))
+    this.limiter = new Bottleneck(
+      Object.assign(
+        {
+          maxConcurrent: 2,
+          minTime: 1000 / 9,
+        },
+        options.limiter
+      )
+    )
 
     this.broadcasts = new Broadcast(this)
     this.campaigns = new Campaign(this)
@@ -70,8 +75,8 @@ class Client extends EventEmitter {
 
   requestStats() {
     return {
-      running: limiter.running(),
-      queued: limiter.queued(),
+      running: this.limiter.running(),
+      queued: this.limiter.queued(),
     }
   }
 
@@ -124,7 +129,7 @@ class Client extends EventEmitter {
 
     return this.checkApiLimit(params).then(() => {
       this.emit('apiCall', params)
-      return limiter.schedule(() =>
+      return this.limiter.schedule(() =>
         request(params)
           .then(res => {
             this.updateApiLimit(res)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Why:
- Gives the user more flexibility. Ex: can use to lower rate use on one instance and raise it for another. 
- Allows user to pass [other options](https://github.com/SGrondin/bottleneck#constructor) to Bottleneck.

Also updated `.travis.yml` to include more node versions. V6 is still broken due to the spread operators.