### PR TITLE
Add options to contact.getById

### DIFF
--- a/lib/contact.js
+++ b/lib/contact.js
@@ -50,10 +50,11 @@ class Contact {
     })
   }
 
-  getById(id) {
+  getById(id, options) {
     return this.client._request({
       method: 'GET',
       path: '/contacts/v1/contact/vid/' + id + '/profile',
+      qs: options,
     })
   }
 

--- a/lib/typescript/contact.ts
+++ b/lib/typescript/contact.ts
@@ -8,7 +8,12 @@ declare class Contact {
 
   getByEmailBatch(email: string[]): RequestPromise
 
-  getById(number: string): RequestPromise
+  getById(number: string, opts?: {
+    property?: string[],
+    propertyMode?: string,
+    formSubmissionMode?: string,
+    showListMemberships?: boolean
+  }): RequestPromise
 
   getByIdBatch(ids: number[]): RequestPromise
 


### PR DESCRIPTION
Why:

- `contacts.getById` pre-this-branch only takes `id`, but per Hub Spot spec there are more options that can go into the URL query string (as it is a GET)

This change addresses the need by:

- https://github.com/MadKudu/node-hubspot/issues/162

---

NOTES:

* Not sure how we'd test the specifics with the current mock implementation
* Haven't actually tried this change against HubSpot