### PR TITLE
Added merge contacts method

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ hubspot.contacts.getRecentlyCreated()
 hubspot.contacts.getRecentlyModified()
 hubspot.contacts.createOrUpdate(email, data)
 hubspot.contacts.delete(id)
+hubspot.contacts.merge(primaryId, secondaryId)
 ```
 
 ### Contact properties

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -113,6 +113,17 @@ class Contact {
     })
   }
 
+  merge(primayVid, secondaryVid) {
+    const data = {
+      vidToMerge: secondaryVid
+    }
+    return this.client._request({
+      method: 'POST',
+      path: '/contacts/v1/contact/merge-vids/' + primayVid ,
+      body: data,
+    })
+  }
+
   search(query, options) {
     if (!options) options = {}
     options.q = query

--- a/test/contacts.js
+++ b/test/contacts.js
@@ -438,4 +438,39 @@ describe('contacts', function() {
       })
     })
   })
+
+  describe('merge', function() {
+    let primaryVid = 12345
+    let secondaryVid = 3456
+    let mergeData = { primaryVid: primaryVid, secondaryVid: secondaryVid }
+
+    let c = []
+
+    const mergeEndpoint = {
+      path: '/contacts/v1/contact/merge-vids/',
+      statusCode: 200,
+      request: mergeData,
+    }
+    fakeHubspotApi.setupServer({
+      postEndpoints: [mergeEndpoint],
+    })
+
+    before(function() {
+      if (process.env.NOCK_OFF) {
+        return hubspot.contacts.get({count: 2}).then(data => {
+          c = data.contacts.map(a => a.vid)
+          primaryVid = c[0]
+          secondaryVid = c[1]
+        })
+      }
+    })
+
+    it('should merge the {primaryVid} contact in {secondaryVid} contact ', function () {
+      return hubspot.contacts
+          .merge(primaryVid, secondaryVid)
+          .then(data => {
+            expect(data).to.equal("SUCCESS")
+          })
+    })
+  })
 })

--- a/test/contacts.js
+++ b/test/contacts.js
@@ -3,9 +3,12 @@ const fakeHubspotApi = require('./helpers/fake_hubspot_api')
 const { createTestContact, deleteTestContact } = require('./helpers/factories')
 
 const Hubspot = require('..')
+
 const emailsFromContacts = contacts =>
   contacts.flatMap(contact =>
-    contact['identity-profiles'].map(
+    contact['identity-profiles'].filter( function (el) {
+      return el.identities.length > 0
+    }).map(
       profile =>
         profile.identities.find(identity => identity.type === 'EMAIL').value
     )


### PR DESCRIPTION
Why: I have an use case where I need to merge two contacts: this happens when a contact on my website make a purchase using an email, then he change his email later. For a number of reason I want to have both contacts separated on hubspot until I will merge them by API.

