### PR TITLE
Added vars for static variables in tests so that contributors can set…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 yarn.lock
 coverage
 .nyc_output
+.vscode

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "tsc": "tsc",
     "ts-node": "ts-node test/typescript/hubspot.ts",
     "mocha": "mocha --recursive test/ --timeout 15000",
+    "mocha-debug": "mocha --inspect=9229 test/",
     "eslint": "eslint . --fix",
     "prettier": "prettier --write {lib,test}/**/*.{js,ts}",
     "watch-test": "mocha --recursive test/ --timeout 15000 --watch"

--- a/test/client.js
+++ b/test/client.js
@@ -9,7 +9,7 @@ describe('client', function() {
 
   describe('apiKey', function() {
     before(() => {
-      hubspot = new Hubspot({ apiKey: 'demo' })
+      hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
     })
 
     it('should instantiate all methods', function() {

--- a/test/companies.js
+++ b/test/companies.js
@@ -2,7 +2,7 @@ var chai = require('chai')
 var expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 const _ = require('lodash')
 
 describe('companies', function() {
@@ -15,6 +15,7 @@ describe('companies', function() {
     })
 
     it('should return a limited number of companies', function() {
+      // you need to run the tests at least 6 times to have enough companies for this test to pass
       return hubspot.companies.get({ limit: 5 }).then(data => {
         expect(data).to.be.an('object')
         expect(data.companies).to.be.a('array')

--- a/test/company_properties.js
+++ b/test/company_properties.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 const property = {
   name: 'mk_company_fit_segment',

--- a/test/company_properties_groups.js
+++ b/test/company_properties_groups.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 const group = {
   displayName: 'GROUP DIPLAY NAME',

--- a/test/deal_properties.js
+++ b/test/deal_properties.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 const property = {
   name: 'mk_deal_fit_segment',

--- a/test/deal_properties_group.js
+++ b/test/deal_properties_group.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 const group = {
   displayName: 'GROUP DIPLAY NAME',

--- a/test/engagements.js
+++ b/test/engagements.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 describe('Engagements', function() {
   describe('Get All Engagements', function() {

--- a/test/files.js
+++ b/test/files.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 describe('files', function() {
   describe('get', function() {

--- a/test/owners.js
+++ b/test/owners.js
@@ -8,7 +8,7 @@ describe('Owners', function() {
 
   describe('get', function() {
     it('Should return all owners', function() {
-      const hubspot = new Hubspot({ apiKey: 'demo' })
+      const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
       return hubspot.owners.get().then(data => {
         expect(data).to.be.a('array')

--- a/test/page.js
+++ b/test/page.js
@@ -2,7 +2,7 @@ var chai = require('chai')
 var expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 describe('pages', function() {
   describe('get', function() {

--- a/test/pipelines.js
+++ b/test/pipelines.js
@@ -2,7 +2,7 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 describe('Pipelines', function() {
   describe('get', function() {

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -2,10 +2,12 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 describe('subscriptions', function() {
   describe('get', function() {
+    // you need to have at least 3 contacts with subscription for the test to work in your hubspot account 
+    // refer to this documentation > https://knowledge.hubspot.com/articles/kcs_article/contacts/manage-your-subscription-preferences-and-types
     it('Should return a list of subscriptions', function() {
       return hubspot.subscriptions.get().then(data => {
         expect(data.timeline).to.be.a('array')

--- a/test/workflows.js
+++ b/test/workflows.js
@@ -2,10 +2,10 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: 'demo' })
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY })
 
 describe('workflows', function() {
-  let workflowId = 2641273
+  let workflowId = process.env.TEST_WORKFLOW_ID
   let contactId
   let contactEmail
 


### PR DESCRIPTION
Why:

- I wanted to contribute to this repo and wasn't able to make the test pass locally

This change addresses the need by:

- Adding 2 variables needed to be able to run the test in a testing environment in the .env file

HUBSPOT_API_KEY
TEST_WORKFLOW_ID
