### PR TITLE
add getPortalInfo method to OAuth

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -51,6 +51,13 @@ class OAuth {
         return results
       })
   }
+
+  getPortalInfo() {
+    return this.client._request({
+      method: 'GET',
+      path: `/oauth/v1/access-tokens/${this.client.accessToken}`
+    })
+  }
 }
 
 module.exports = OAuth

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -98,4 +98,40 @@ describe('oauth', function() {
       })
     }
   })
+
+
+  describe('getPortalInfo', function() {
+    beforeEach(() => {
+      hubspot = new Hubspot()
+    })
+    
+    const accessToken = "fake_access_token"
+    const getPortalInfoEndpoint = {
+      path: `/oauth/v1/token/${accessToken}`,
+      response: {
+        "token": accessToken,
+        "user": "test@hubspot.com",
+        "hub_domain": "demo.hubapi.com",
+        "scopes": [
+          "contacts",
+          "automation",
+          "oauth"
+        ],
+        "hub_id": 62515,
+        "app_id": 456,
+        "expires_in": 21588,
+        "user_id": 123,
+        "token_type": "access"
+      }
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [getPortalInfoEndpoint] })
+
+    it('should return the Portal metadata for a given portal', function() {
+      return hubspot.oauth.getPortalInfo(accessToken).then(response => {
+        console.log(response)
+        expect(response).to.be.a('object')
+        expect(response).to.contain('hub_id')
+      })
+    })
+  })
 })

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -99,39 +99,4 @@ describe('oauth', function() {
     }
   })
 
-
-  describe('getPortalInfo', function() {
-    beforeEach(() => {
-      hubspot = new Hubspot()
-    })
-    
-    const accessToken = "fake_access_token"
-    const getPortalInfoEndpoint = {
-      path: `/oauth/v1/token/${accessToken}`,
-      response: {
-        "token": accessToken,
-        "user": "test@hubspot.com",
-        "hub_domain": "demo.hubapi.com",
-        "scopes": [
-          "contacts",
-          "automation",
-          "oauth"
-        ],
-        "hub_id": 62515,
-        "app_id": 456,
-        "expires_in": 21588,
-        "user_id": 123,
-        "token_type": "access"
-      }
-    }
-    fakeHubspotApi.setupServer({ postEndpoints: [getPortalInfoEndpoint] })
-
-    it('should return the Portal metadata for a given portal', function() {
-      return hubspot.oauth.getPortalInfo(accessToken).then(response => {
-        console.log(response)
-        expect(response).to.be.a('object')
-        expect(response).to.contain('hub_id')
-      })
-    })
-  })
 })

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -98,5 +98,4 @@ describe('oauth', function() {
       })
     }
   })
-
 })


### PR DESCRIPTION
Why:

- to be able to get portal info from an access token

This change addresses the need by:

- adding a method to oauth.js

Would love help adding a test here, I failed to do so successfully
