### PR TITLE
getting profile from accesstoken was missing

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -51,6 +51,14 @@ class OAuth {
         return results
       })
   }
+  
+  getProfile() {
+    return this.client
+      ._request({
+        method: 'GET',
+        path: '/oauth/v1/access-tokens/' + this.client.accessToken
+      })
+  }
 }
 
 module.exports = OAuth


### PR DESCRIPTION
added getProfile so that user can know, profile of the accessToken

Why:

- This [API](https://developers.hubspot.com/docs/methods/oauth2/get-access-token-information) was missing
