### PR TITLE
Update method getByDomain to use new hubspot API URL

### DIFF
--- a/lib/company.js
+++ b/lib/company.js
@@ -46,8 +46,8 @@ class Company {
 
   getByDomain(domain) {
     return this.client._request({
-      method: 'GET',
-      path: '/companies/v2/companies/domain/' + domain,
+      method: 'POST',
+      path: `/companies/v2/domains/${domain}/companies`,
     })
   }
 


### PR DESCRIPTION
#Why:

- Seems like HubSpot changed `companies.getByDomain` related API URL. Update the wrapper code accordingly.

Issue: #150

Documentation here:
https://developers.hubspot.com/docs/methods/companies/search_companies_by_domain