### PR TITLE
Add missed payload for getByDomain POST API request.

### DIFF
--- a/lib/company.js
+++ b/lib/company.js
@@ -44,10 +44,11 @@ class Company {
     })
   }
 
-  getByDomain(domain) {
+  getByDomain(domain, data) {
     return this.client._request({
       method: 'POST',
       path: `/companies/v2/domains/${domain}/companies`,
+      body: data,
     })
   }
 

--- a/test/companies.js
+++ b/test/companies.js
@@ -70,11 +70,22 @@ describe('companies', function() {
   describe('getByDomain', function() {
     it('should returns a list of all companies that have a matching domain to the specified domain in the request URL', function() {
       this.timeout(10000)
-      return hubspot.companies.getByDomain('example.com').then(data => {
-        // console.log(data)
-        expect(data).to.be.an('array')
-        expect(data[0].properties.domain.value).to.equal('example.com')
-      })
+      const payload = {
+        limit: 2,
+        requestOptions: {
+          properties: ['domain', 'createdate', 'name', 'hs_lastmodifieddate'],
+        },
+        offset: {
+          isPrimary: true,
+          companyId: 0,
+        },
+      }
+      return hubspot.companies.getByDomain('example.com', payload).then(data => {
+          // console.log(data)
+          expect(data).to.be.an('object')
+          expect(data.results).to.be.an('array')
+          expect(data.results[0].properties.domain.value).to.equal('example.com')
+        })
     })
   })
 


### PR DESCRIPTION
Why:

- Hubspot changed API signature. Need to update URL, Http method and payload as well.

This change addresses the need by: https://github.com/MadKudu/node-hubspot/issues/150