### PR TITLE
Fix authorization URL generation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ hubspot.emails.sendTransactionalEmail(data)
 ```javascript
 const params = {
   client_id: 'your_client_id',
-  scopes: 'some scopes',
+  scope: 'some scopes',
   redirect_uri: 'take_me_to_the_ballpark',
 }
 const uri = hubspot.oauth.getAuthorizationUrl(params)

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -6,11 +6,11 @@ class OAuth {
   }
 
   getAuthorizationUrl(data) {
-    const newParams = {
-      client_id: this.client.clientId,
-      redirect_uri: this.client.redirectUri,
-    }
-    const params = Object.assign({}, data, newParams)
+    const initialParams = {}
+    if (this.client.clientId) initialParams.client_id = this.client.clientId
+    if (this.client.redirectUri) initialParams.redirect_uri = this.client.redirectUri
+
+    const params = Object.assign({}, initialParams, data)
     return 'https://app.hubspot.com/oauth/authorize?' + qs.stringify(params)
   }
 

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -10,15 +10,47 @@ describe('oauth', function() {
       hubspot = new Hubspot()
     })
 
-    it('should return the correct authorizationUrl for a given app', function() {
+    it('should return the correct authorizationUrl for a given app using provided params', function() {
       const params = {
         client_id: 'fake_client_id',
-        scopes: 'some scopes',
+        scope: 'some scopes',
         redirect_uri: 'take_me_to_the_ballpark',
       }
+      const expectedURL = 'https://app.hubspot.com/oauth/authorize?client_id=fake_client_id&scope=some%20scopes&redirect_uri=take_me_to_the_ballpark';
+      const uri = hubspot.oauth.getAuthorizationUrl(params)
+      console.log(uri)
+      expect(uri).to.be.a('string')
+      expect(uri).to.be.eq(expectedURL)
+    })
+
+    it('should return the correct authorizationUrl for a given app using Habspot constructor values', function() {
+      hubspot = new Hubspot({
+        clientId: 'fake_client_id',
+        redirectUri: 'take_me_to_the_ballpark',
+      })
+      const params = {
+        scope: 'some scopes',
+      }
+      const expectedURL = 'https://app.hubspot.com/oauth/authorize?client_id=fake_client_id&redirect_uri=take_me_to_the_ballpark&scope=some%20scopes';
       const uri = hubspot.oauth.getAuthorizationUrl(params)
       expect(uri).to.be.a('string')
-      expect(uri).to.contain('scopes=some%20scopes')
+      expect(uri).to.be.eq(expectedURL)
+    })
+
+    it('should return the correct authorizationUrl for a given app and override initial params if provided', function() {
+      hubspot = new Hubspot({
+        clientId: 'fake_client_id',
+        redirectUri: 'take_me_to_the_ballpark',
+      })
+      const params = {
+        client_id: 'params_fake_client_id',
+        scope: 'some scopes',
+        redirect_uri: 'params_take_me_to_the_ballpark',
+      }
+      const expectedURL = 'https://app.hubspot.com/oauth/authorize?client_id=params_fake_client_id&redirect_uri=params_take_me_to_the_ballpark&scope=some%20scopes';
+      const uri = hubspot.oauth.getAuthorizationUrl(params)
+      expect(uri).to.be.a('string')
+      expect(uri).to.be.eq(expectedURL)
     })
   })
 


### PR DESCRIPTION
Why:

- Use `Object.assign` correctly for generation authorization URL 

This change addresses the need by:

https://github.com/MadKudu/node-hubspot/issues/172
