### PR TITLE
Add refreshAccessToken definition to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,12 @@ export interface AccessTokenOptions extends BaseOptions, LimiterOptions {
   accessToken: string
 }
 
+export interface AccessTokenResponse {
+  refresh_token: string;
+  access_token: string;
+  expires_in: number;
+}
+
 export interface AppOptions extends BaseOptions {
   clientId: string
   clientSecret: string
@@ -67,6 +73,7 @@ export interface HubspotError {
 
 declare class Hubspot {
   constructor(options?: ApiOptions | AccessTokenOptions | AppOptions)
+  refreshAccessToken(): Promise<AccessTokenResponse>
   companies: Company
   contacts: Contact
   pages: Page


### PR DESCRIPTION
**Why**: Improved typescript support for HubSpot app developers using OAuth.

**This change addresses the need by**: adding type hinting for the `refreshAccessToken()` method on the HubSpot client.

Closes #193