### PR TITLE
Document Workflow Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,16 @@ from the resolved promise.
 hubspot.emails.sendTransactionalEmail(data)
 ```
 
+### Workflows
+
+```javascript
+hubspot.workflows.getAll()
+hubspot.workflows.get(workflowId)
+hubspot.workflows.enroll(workflowId, email)
+hubspot.workflows.unenroll(workflowId, email)
+hubspot.workflows.current(contactId)
+```
+
 ### OAuth
 
 #### Obtain your authorization url

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ import { Broadcast } from './lib/typescript/broadcast'
 import { CRM } from './lib/typescript/crm'
 import { Emails } from './lib/typescript/emails'
 import { Form } from './lib/typescript/form'
+import { Workflow } from './lib/typescript/workflow';
 
 interface BaseOptions {
   baseUrl?: string
@@ -84,6 +85,7 @@ declare class Hubspot {
   crm: CRM
   emails: Emails
   forms: Form
+  workflows: Workflow
 }
 
 export default Hubspot

--- a/lib/typescript/workflow.ts
+++ b/lib/typescript/workflow.ts
@@ -1,0 +1,15 @@
+import { RequestPromise } from 'request-promise'
+
+declare class Workflow {
+  get(workflowId: number): RequestPromise
+
+  getAll(): RequestPromise
+
+  enroll(workflowId: number, email: string): RequestPromise
+
+  unenroll(workflowId: number, email: string): RequestPromise
+
+  current(contactId: string): RequestPromise
+}
+
+export { Workflow }


### PR DESCRIPTION
**Why**: Unless you read through the source code, it is not apparent that this package supports interacting with HubSpot workflows.

**This change addresses the need by**:
- Adding documentation to `README.md` for Workflow client methods that are already implemented
- Adding typescript definitions for the aforementioned Workflow methods

Closes #171 