### PR TITLE
Add delete method for deal property group instance

### DIFF
--- a/lib/deal_property_group.js
+++ b/lib/deal_property_group.js
@@ -31,6 +31,13 @@ class DealGroups {
     })
   }
 
+  delete(groupName) {
+    return this.client._request({
+      method: 'DELETE',
+      path: `/properties/v1/deals/groups/named/${groupName}`,
+    })
+  }
+
   upsert(data) {
     return this.create(data).catch((err) => {
       if (err.statusCode === 409) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -10,17 +10,17 @@ class Subscription {
       qs: options,
     })
   }
-  
+
   unsubscribe(email) {
     return this.client._request({
       method: 'PUT',
       path: `/email/public/v1/subscriptions/${email}`,
       body: {
-        unsubscribeFromAll: true
+        unsubscribeFromAll: true,
       },
     })
   }
-  
+
   subscribeToAll(email) {
     return this.client._request({
       method: 'PUT',

--- a/lib/typescript/deal_property_group.ts
+++ b/lib/typescript/deal_property_group.ts
@@ -7,6 +7,8 @@ declare class Groups {
 
   update(name: string, data: {}): RequestPromise
 
+  delete(name: string): RequestPromise
+
   upsert(name: string, data: {}): RequestPromise
 }
 

--- a/test/deal_properties_group.js
+++ b/test/deal_properties_group.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const chai = require('chai')
 const expect = chai.expect
 
@@ -5,7 +6,7 @@ const Hubspot = require('..')
 const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY || 'demo' })
 
 const group = {
-  displayName: 'GROUP DIPLAY NAME',
+  displayName: 'GROUP DISPLAY NAME',
   name: 'mk_group_fit_segment',
 }
 
@@ -51,6 +52,23 @@ describe('deals.properties.groups', () => {
           expect(data).to.be.an('object')
           expect(data).to.have.a.property('name')
           expect(data.displayName).to.equal(group.displayName)
+        })
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete property group', () => {
+      const groupToDelete = Object.assign({}, group, {
+        name: `mk_group_fit_segment_for_delete`,
+      })
+      return hubspot.deals.properties.groups
+        .create(groupToDelete)
+        .then(() => hubspot.deals.properties.groups.delete(groupToDelete.name))
+        .then(() => hubspot.deals.properties.groups.get())
+        .then((data) => {
+          expect(data).to.be.an('array')
+          const result = _.find(data, { name: groupToDelete.name })
+          expect(result).to.be.an('undefined')
         })
     })
   })


### PR DESCRIPTION
Why:

Add delete method for deal property group instance

This change addresses the need by:

https://github.com/MadKudu/node-hubspot/issues/94
