### PR TITLE
Add engagements update method. Update Nock helper with PATCH request

### DIFF
--- a/lib/engagement.js
+++ b/lib/engagement.js
@@ -40,6 +40,14 @@ class Engagement {
     })
   }
 
+  update(engagementId, data) {
+    return this.client._request({
+      method: 'PATCH',
+      path: `/engagements/v1/engagements/${engagementId}`,
+      body: data,
+    })
+  }
+
   getCallDispositions() {
     return this.client._request({
       method: 'GET',

--- a/lib/typescript/engagement.ts
+++ b/lib/typescript/engagement.ts
@@ -5,9 +5,13 @@ declare class Engagement {
 
   get(opts?: {}): RequestPromise
 
+  update(engagementId: string, data: {}): RequestPromise
+
   getRecentlyModified(opts?: {}): RequestPromise
 
   getAssociated(objectType: string, objectId: number, opts?: {}): RequestPromise
+
+  getCallDispositions(): RequestPromise
 }
 
 export { Engagement }

--- a/test/engagements.js
+++ b/test/engagements.js
@@ -2,7 +2,8 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
-const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY || 'demo' })
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
+let hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY || 'demo' })
 
 describe('Engagements', () => {
   describe('Get All Engagements', () => {
@@ -34,6 +35,50 @@ describe('Engagements', () => {
         expect(data[0]).to.have.a.property('label')
       })
     })
+  })
+
+  describe('update', () => {
+    const engagementId = 'fake_engagement_id'
+    const clientProperties = {
+      clientId: 'fake_client_id',
+      clientSecret: 'fake_client_secret',
+      redirectUri: 'some-redirect-uri',
+      refreshToken: 'a_fake_refresh_token',
+      accessToken: 'a_fake_access_token',
+    }
+    const expectedResponse = {
+      updated: true,
+    }
+    const engagementsBody = {
+      engagement: {
+        ownerId: 1,
+        timestamp: 1409172644778,
+      },
+      metadata: {
+        body: 'a new note body',
+      },
+    }
+    const engagementsEndpoint = {
+      path: `/engagements/v1/engagements/${engagementId}`,
+      request: engagementsBody,
+      response: expectedResponse,
+    }
+    fakeHubspotApi.setupServer({ patchEndpoints: [engagementsEndpoint] })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should update engagement', () => {
+        hubspot = new Hubspot(clientProperties)
+
+        return hubspot.engagements
+          .update(engagementId, engagementsBody)
+          .then((data) => {
+            expect(data).to.be.an('object')
+            expect(data).to.be.deep.equal(expectedResponse)
+          })
+      })
+    }
   })
 
   // Test too brittle. First contactId doesn't necessarily has engagement

--- a/test/helpers/fake_hubspot_api.js
+++ b/test/helpers/fake_hubspot_api.js
@@ -6,6 +6,7 @@ class FakeHubSpotApi {
     getEndpoints = [],
     postEndpoints = [],
     putEndpoints = [],
+    patchEndpoints = [],
     deleteEndpoints = [],
   } = {}) {
     let maybeAddHapiKeyToQuery = (x) => x
@@ -23,6 +24,9 @@ class FakeHubSpotApi {
       getEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockGetEndpoint)
       postEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockPostEndpoint)
       putEndpoints.map(maybeAddHapiKeyToQuery).map(nockHelper.mockPutEndpoint)
+      patchEndpoints
+        .map(maybeAddHapiKeyToQuery)
+        .map(nockHelper.mockPatchEndpoint)
       deleteEndpoints
         .map(maybeAddHapiKeyToQuery)
         .map(nockHelper.mockDeleteEndpoint)

--- a/test/helpers/nock_helper.js
+++ b/test/helpers/nock_helper.js
@@ -60,6 +60,11 @@ class NockHelper {
     mockEndpoint(parameters)
   }
 
+  mockPatchEndpoint(parameters) {
+    parameters.verb = 'PATCH'
+    mockEndpoint(parameters)
+  }
+
   mockDeleteEndpoint(parameters) {
     parameters.verb = 'DELETE'
     mockEndpoint(parameters)


### PR DESCRIPTION
Why:

Add engagements update method

This change addresses the need by:

https://github.com/MadKudu/node-hubspot/issues/173