### PR TITLE
Fix update email url

### DIFF
--- a/lib/contact.js
+++ b/lib/contact.js
@@ -108,7 +108,7 @@ class Contact {
   updateByEmail(email, data) {
     return this.client._request({
       method: 'POST',
-      path: `/contacts/v1/contact/createOrUpdate/email/${email}/profile`,
+      path: `/contacts/v1/contact/email/${email}/profile`,
       body: data,
     })
   }

--- a/test/contacts.js
+++ b/test/contacts.js
@@ -321,7 +321,7 @@ describe('contacts', () => {
       ],
     }
     const updateByEmailEndpoint = {
-      path: `/contacts/v1/contact/createOrUpdate/email/${email}/profile`,
+      path: `/contacts/v1/contact/email/${email}/profile`,
       request: updateByEmailData,
       response: {
         updated: true,


### PR DESCRIPTION
Why:

- The contacts.updateByEmail is not using the accurate URL for Hubspot API

This change addresses the need by:

- Making updateByEmail function work
