### PR TITLE
added expiresIn and updatedAt to the client object in the setAcessToken method.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -86,8 +86,11 @@ class Client extends EventEmitter {
     }
   }
 
-  setAccessToken(accessToken) {
+  setAccessToken(accessToken, expiresIn = 0, updatedAt = 0) {
     this.accessToken = accessToken
+    this.accessTokenExpiresIn = expiresIn
+    this.accessTokenUpdatedAt =
+      updatedAt !== 0 ? updatedAt : Math.floor(Date.now() / 1000) // current timestamp in seconds
     this.auth = { bearer: accessToken }
   }
 
@@ -110,7 +113,13 @@ class Client extends EventEmitter {
         this.qs.access_token = options.accessToken
       } else {
         // defaults to OAuth2
-        this.setAccessToken(options.accessToken)
+        let updatedAtTimestamp = options.hasOwnProperty('updatedAtTimestamp')
+          ? options.updatedAtTimestamp
+          : Math.floor(Date.now() / 1000) // current timestamp in seconds
+        let expiresIn = options.hasOwnProperty('expiresIn')
+          ? options.expiresIn
+          : 21600
+        this.setAccessToken(options.accessToken, expiresIn, updatedAtTimestamp)
       }
     }
   }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -48,7 +48,12 @@ class OAuth {
         form,
       })
       .then((results) => {
-        this.client.setAccessToken(results.access_token) // refresh the new access_token on the client
+        let updatedAt = Math.floor(Date.now() / 1000) // current timestamp in seconds
+        this.client.setAccessToken(
+          results.access_token,
+          results.expires_in,
+          updatedAt
+        ) // refresh the new access_token on the client
         return results
       })
   }


### PR DESCRIPTION
Why:

- since the ```refreshAccessToken()``` and ```getAccessToken()``` methods "decorate" the self object with the properties ```refreshToken``` and ```accessToken``` (both returned by the methods above) it could be less misleading have a ```expiresIn``` property containing the value as resulted from the methods, and another property ```updatedAt``` containing the timestamp of the creation/update time.

Details

This values are set in the ```setAccessToken``` and  used by the methods
- client.setAuth
- oauth.refreshAccessToken

Default values for this variables are
- expiresIn --> 21600
- updatedAt : current_timestamp
