### PR TITLE
Extend apiRequest method allow to overlap Url. Update forms method to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,15 @@ hubspot.apiRequest({
           })
 ```
 
+Also it is possible to overlap hubspot base API URL using `overlapUrl` parameter
+
+```javascript
+hubspot.apiRequest({
+            method: 'GET',
+            overlapUrl: 'https://api.hubspot.com/some/alternative/api',
+          })
+```
+
 ## Typescript
 
 You may use this library in your Typescript project via:

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,8 +75,9 @@ declare class Hubspot {
   constructor(options?: ApiOptions | AccessTokenOptions | AppOptions)
   refreshAccessToken(): Promise<AccessTokenResponse>
   apiRequest(options: {
-    method: string,
-    path: string,
+    method?: string,
+    path?: string,
+    overlapUrl?: string,
     body?: any,
     qs?: any,
     useQuerystring?: boolean,

--- a/lib/client.js
+++ b/lib/client.js
@@ -132,10 +132,12 @@ class Client extends EventEmitter {
     if (this.auth) {
       params.auth = this.auth
     }
+    params.method = params.method || 'GET'
     params.json = true
     params.resolveWithFullResponse = true
 
-    params.url = this.baseUrl + params.path
+    params.url = params.overlapUrl || this.baseUrl + (params.path || '')
+    delete params.overlapUrl
     delete params.path
     params.qs = Object.assign({}, this.qs, params.qs)
 

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,4 +1,3 @@
-const request = require('request-promise')
 class Form {
   constructor(client) {
     this.client = client
@@ -46,11 +45,9 @@ class Form {
   }
 
   submit(portalId, formId, data) {
-    return request({
-      json: true,
-      headers: { 'Content-Type': 'application/json' },
+    return this.client.apiRequest({
       method: 'POST',
-      url: `https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`,
+      overlapUrl: `https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`,
       body: data,
     })
   }
@@ -79,9 +76,9 @@ class Form {
   }
 
   getUploadedFileByUrl(url) {
-    return request({
+    return this.client.apiRequest({
       method: 'GET',
-      url: url,
+      overlapUrl: url,
     })
   }
 }

--- a/test/forms.js
+++ b/test/forms.js
@@ -209,13 +209,13 @@ describe('forms', () => {
         conversionId,
         filename,
       },
-      headers: { host: 'api.hubspot.com' },
-      response: 'success',
+      response: { success: true },
     }
 
     fakeHubspotApi.setupServer({
       getEndpoints: [formEndpoint],
       basePath: 'https://api.hubspot.com',
+      demo: true,
     })
 
     if (process.env.NOCK_OFF) {
@@ -223,7 +223,7 @@ describe('forms', () => {
     } else {
       it('correctly make request by the url', () => {
         return hubspot.forms.getUploadedFileByUrl(url).then((data) => {
-          expect(data).to.be.eq('success')
+          expect(data.success).to.be.eq(true)
         })
       })
     }


### PR DESCRIPTION
Extend client request wrapper `apiRequest` allows using alternative urls. Update forms methods accordingly
