### PR TITLE
Delete contacts from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ hubspot.lists.delete(id)
 hubspot.lists.getContacts(id, opts)
 hubspot.lists.getRecentContacts(id, opts)
 hubspot.lists.addContacts(id, contactBody)
+hubspot.lists.removeContacts(id, contactBody)
 ```
 
 ### Files

--- a/lib/list.js
+++ b/lib/list.js
@@ -79,6 +79,23 @@ class List {
       body,
     })
   }
+
+  removeContacts(id, contactBody) {
+    if (!id) {
+      return Promise.reject(new Error('id parameter must be provided.'))
+    }
+    if (!contactBody) {
+      return Promise.reject(new Error('contactBody parameter must be provided.'))
+    }
+
+    var body = contactBody
+
+    return this.client.apiRequest({
+      method: 'POST',
+      path: `/contacts/v1/lists/${id}/remove`,
+      body,
+    })
+  }
 }
 
 module.exports = List

--- a/lib/typescript/list.ts
+++ b/lib/typescript/list.ts
@@ -10,6 +10,8 @@ declare class List {
   getRecentContacts(id: number): RequestPromise
 
   addContacts(id: number, contactBody: {}): RequestPromise
+
+  removeContacts(id: number, contactBody: {}): RequestPromise
 }
 
 export { List }

--- a/test/lists.js
+++ b/test/lists.js
@@ -189,4 +189,48 @@ describe('lists', () => {
       })
     })
   })
+
+  describe('removeContacts', () => {
+    describe('when a id and contactBody is provided', () => {
+      const listId = 123
+      const contactId = 234
+      const removeContactsFromListEndpoint = {
+        path: `/contacts/v1/lists/${listId}/remove`,
+        request: { vids: [contactId] },
+        response: { contacts: [] },
+      }
+      fakeHubspotApi.setupServer({ postEndpoints: [removeContactsFromListEndpoint] })
+      it('should return results', () => {
+        return hubspot.lists.removeContacts(listId, { vids: [contactId] }).then((data) => {
+          expect(data).to.be.a('object')
+        })
+      })
+    })
+
+    describe('when not passed a listId', () => {
+      it('should return a rejected promise', () => {
+        return hubspot.lists
+          .removeContacts()
+          .then(() => {
+            throw new Error('I should have thrown an error')
+          })
+          .catch((error) => {
+            expect(error.message).to.equal('id parameter must be provided.')
+          })
+      })
+    })
+
+    describe('when passed a listId but not contactBody', () => {
+      it('should return a rejected promise', () => {
+        return hubspot.lists
+          .removeContacts(123)
+          .then(() => {
+            throw new Error('I should have thrown an error')
+          })
+          .catch((error) => {
+            expect(error.message).to.equal('contactBody parameter must be provided.')
+          })
+      })
+    })
+  })
 })


### PR DESCRIPTION
These changes implement HubSpot's `/contacts/v1/lists/:list_id/remove` endpoint. The new `removeContacts` method takes a list ID and `contactBody` (similar to `addContacts`).

This change addresses the need by https://github.com/MadKudu/node-hubspot/issues/241
