### PR TITLE
Added marketing email

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,16 @@ hubspot.campaigns.getOne(id)
 hubspot.campaigns.events(opts)
 ```
 
+### Marketing Email
+
+```javascript
+hubspot.marketingEmail.get(opts)
+hubspot.marketingEmail.getById(id)
+hubspot.marketingEmail.create(data)
+hubspot.marketingEmail.update(id, data)
+hubspot.marketingEmail.delete(id)
+```
+
 ### Social Media
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ import { Form } from './lib/typescript/form'
 import { Workflow } from './lib/typescript/workflow';
 import {Timeline} from "./lib/typescript/timeline";
 import { RequestPromise } from 'request-promise'
+import { MarketingEmail } from './lib/typescript/marketing_email'
 
 interface BaseOptions {
   baseUrl?: string
@@ -103,6 +104,7 @@ declare class Hubspot {
   emails: Emails
   forms: Form
   workflows: Workflow
+  marketingEmail: MarketingEmail
 }
 
 export default Hubspot

--- a/lib/client.js
+++ b/lib/client.js
@@ -22,6 +22,7 @@ const Pipeline = require('./pipeline')
 const Subscription = require('./subscription')
 const Timeline = require('./timeline')
 const Workflow = require('./workflow')
+const MarketingEmail = require('./marketing_email')
 
 const debug = require('debug')('hubspot:client')
 
@@ -60,6 +61,7 @@ const setInstances = (client) => {
   client.subscriptions = new Subscription(client)
   client.workflows = new Workflow(client)
   client.crm = new CRM(client)
+  client.marketingEmail = new MarketingEmail(client)
 }
 
 const prepareParams = (opts, self) => {

--- a/lib/marketing_email.js
+++ b/lib/marketing_email.js
@@ -1,0 +1,49 @@
+class MarketingEmail {
+  constructor(client) {
+    this.client = client
+  }
+
+  getAll(options) {
+    return this.get(options)
+  }
+
+  get(options) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: '/marketing-emails/v1/emails',
+      qs: options,
+    })
+  }
+
+  getById(id) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: `/marketing-emails/v1/emails/${id}`,
+    })
+  }
+
+  create(data) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: '/marketing-emails/v1/emails',
+      body: data,
+    })
+  }
+
+  update(id, data) {
+    return this.client.apiRequest({
+      method: 'PUT',
+      path: `/marketing-emails/v1/emails/${id}`,
+      body: data,
+    })
+  }
+
+  delete(id) {
+    return this.client.apiRequest({
+      method: 'DELETE',
+      path: `/marketing-emails/v1/emails/${id}`,
+    })
+  }
+}
+
+module.exports = MarketingEmail

--- a/lib/typescript/marketing_email.ts
+++ b/lib/typescript/marketing_email.ts
@@ -1,0 +1,17 @@
+import { RequestPromise } from 'request-promise'
+
+declare class MarketingEmail {
+  getAll(opts?: {}): RequestPromise
+
+  get(opts?: {}): RequestPromise
+
+  getById(id: string): RequestPromise
+
+  create(data: {}): RequestPromise
+
+  update(id: string, data: {}): RequestPromise
+
+  delete(id: string): RequestPromise
+}
+
+export { MarketingEmail }

--- a/test/marketing_email.js
+++ b/test/marketing_email.js
@@ -1,0 +1,130 @@
+const { expect } = require('chai')
+
+const Hubspot = require('..')
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
+const hubspot = new Hubspot({ apiKey: process.env.HUBSPOT_API_KEY || 'demo' })
+
+describe('marketingEmail', () => {
+  describe('getAll', () => {
+    it('should return all the marketing emails', () => {
+      return hubspot.marketingEmail.getAll().then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.objects).to.be.a('array')
+        expect(data.objects.length).to.be.above(0)
+      })
+    })
+
+    it('should return a limited number of emails', () => {
+      return hubspot.marketingEmail.get({ limit: 1 }).then((data) => {
+        expect(data.objects).to.be.a('array')
+        expect(data.objects.length).to.be.above(0)
+      })
+    })
+  })
+
+  describe('getById', () => {
+    let id, name, author
+
+    before(() => {
+      return hubspot.marketingEmail.get().then((data) => {
+        id = data.objects[0].id
+        name = data.objects[0].name
+        author = data.objects[0].author
+      })
+    })
+
+    it('should return a email', () => {
+      return hubspot.marketingEmail.getById(id).then((data) => {
+        expect(data).to.be.a('object')
+        expect(data.name).to.eq(name)
+        expect(data.author).to.eq(author)
+      })
+    })
+  })
+
+  describe('create', () => {
+    const payload = {
+      name: 'CREATE: A test marketing email',
+      abVariation: false,
+      htmlTitle: 'htmlTitle',
+      isPublished: false,
+    }
+
+    const emailEndpoint = {
+      path: '/marketing-emails/v1/emails',
+      request: payload,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      postEndpoints: [emailEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should create a marketing email', () => {
+        return hubspot.marketingEmail.create(payload).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+
+  describe('update', () => {
+    const id = 'mock_id'
+    const payload = {
+      fromName: 'Sample Author',
+      emailBody: 'Example email body',
+    }
+
+    const emailEndpoint = {
+      path: `/marketing-emails/v1/emails/${id}`,
+      request: payload,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      putEndpoints: [emailEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can update a marketing email', () => {
+        return hubspot.marketingEmail.update(id, payload).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+
+  describe('delete', () => {
+    const id = 'mock_id'
+
+    const emailEndpoint = {
+      path: `/marketing-emails/v1/emails/${id}`,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      deleteEndpoints: [emailEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can delete a marketing email', () => {
+        return hubspot.marketingEmail.delete(id).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+})


### PR DESCRIPTION
Why:

The client wrapper doesn’t support marketing emails API

This change addresses the need by:

salto.io http://salto.io/
