### PR TITLE
Added workflows create & delete commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ hubspot.emails.sendTransactionalEmail(data)
 ```javascript
 hubspot.workflows.getAll()
 hubspot.workflows.get(workflowId)
+hubspot.workflows.create(data)
+hubspot.workflows.delete(workflowId)
 hubspot.workflows.enroll(workflowId, email)
 hubspot.workflows.unenroll(workflowId, email)
 hubspot.workflows.current(contactId)

--- a/lib/typescript/workflow.ts
+++ b/lib/typescript/workflow.ts
@@ -5,6 +5,10 @@ declare class Workflow {
 
   getAll(): RequestPromise
 
+  create(data: {}): RequestPromise
+
+  delete(workflowId: string): RequestPromise
+
   enroll(workflowId: number, email: string): RequestPromise
 
   unenroll(workflowId: number, email: string): RequestPromise

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -17,6 +17,21 @@ class Workflow {
     })
   }
 
+  create(data) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: '/automation/v3/workflows',
+      body: data,
+    })
+  }
+
+  delete(workflowId) {
+    return this.client.apiRequest({
+      method: 'DELETE',
+      path: `/automation/v3/workflows/${workflowId}`,
+    })
+  }
+
   enroll(workflowId, email) {
     return this.client.apiRequest({
       method: 'POST',

--- a/test/workflows.js
+++ b/test/workflows.js
@@ -33,9 +33,58 @@ describe('workflows', () => {
     })
   })
 
-  describe.skip('create', () => {})
+  describe('create', () => {
+    const payload = {
+      name: 'Test Workflow',
+      type: 'DRIP_DELAY',
+      onlyEnrollsManually: true,
+    }
 
-  describe.skip('delete', () => {})
+    const workflowEndpoint = {
+      path: '/automation/v3/workflows',
+      request: payload,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      postEndpoints: [workflowEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should create an workflow', () => {
+        return hubspot.workflows.create(payload).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+
+  describe('delete', () => {
+    const workflowsEndpoint = {
+      path: `/automation/v3/workflows/${workflowId}`,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      deleteEndpoints: [workflowsEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can delete an workflow', () => {
+        return hubspot.workflows.delete(workflowId).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
 
   describe('enroll', () => {
     const email = 'fake_email'


### PR DESCRIPTION
Why:

The wrapper doesn’t support workflows create & delete commands

This change addresses the need by:

salto.io
