### PR TITLE
Add missing type definitions in Properties types

### DIFF
--- a/lib/typescript/company_property.ts
+++ b/lib/typescript/company_property.ts
@@ -3,6 +3,8 @@ import { RequestPromise } from 'request-promise'
 import { Groups } from './company_property_group'
 
 declare class Properties {
+  getAll(options?: {}): RequestPromise
+
   get(query?: {}): RequestPromise
 
   getByName(name: string): RequestPromise

--- a/lib/typescript/contact_property.ts
+++ b/lib/typescript/contact_property.ts
@@ -1,6 +1,8 @@
 import { RequestPromise } from 'request-promise'
 
 declare class Properties {
+  getAll(options?: {}): RequestPromise
+
   get(): RequestPromise
 
   getByName(name: string): RequestPromise

--- a/lib/typescript/deal_property.ts
+++ b/lib/typescript/deal_property.ts
@@ -2,11 +2,15 @@ import { RequestPromise } from 'request-promise'
 import { Groups } from './deal_property_group'
 
 declare class Properties {
+  getAll(options?: {}): RequestPromise
+
   get(query?: {}): RequestPromise
 
   getByName(name: string): RequestPromise
 
   create(data: {}): RequestPromise
+
+  delete(name: string): RequestPromise
 
   update(name: string, data: {}): RequestPromise
 

--- a/lib/typescript/deal_property_group.ts
+++ b/lib/typescript/deal_property_group.ts
@@ -1,6 +1,8 @@
 import { RequestPromise } from 'request-promise'
 
 declare class Groups {
+  getAll(options?: {}): RequestPromise
+
   get(query?: {}): RequestPromise
 
   create(data: {}): RequestPromise

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Why:

Some of the TypeScript type definitions for Properties (deals, contacts, companies) are missing methods.  Specifically, getAll is not exposed in the TypeScript definition.

This change addresses the need by:

Adding some missing type definitions.
