### PR TITLE
Add missing marketing email endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ npm install hubspot
 
 ```javascript
 const Hubspot = require('hubspot')
-const hubspot = new Hubspot({ 
+const hubspot = new Hubspot({
   apiKey: 'abc',
-  checkLimit: false // (Optional) Specify whether to check the API limit on each call. Default: true 
+  checkLimit: false // (Optional) Specify whether to check the API limit on each call. Default: true
 })
 ```
 
@@ -92,7 +92,7 @@ hubspot.contacts
 
 ## Samples
 
-Please see repository with [samples] applications with common cases. 
+Please see repository with [samples] applications with common cases.
 
 [samples]: https://github.com/HubSpot/integration-examples-nodejs
 
@@ -319,7 +319,7 @@ hubspot.files.uploadByUrl(fileDetails, overwrite, hidden)
 ```javascript
 hubspot.forms.get(opts)
 hubspot.forms.getById(id)
-hubspot.forms.getSingleField(guid, fieldname) 
+hubspot.forms.getSingleField(guid, fieldname)
 hubspot.forms.getSubmissions(guid, opts)
 hubspot.forms.create(data)
 hubspot.forms.update(id, data)
@@ -352,7 +352,13 @@ hubspot.marketingEmail.get(opts)
 hubspot.marketingEmail.getById(id)
 hubspot.marketingEmail.create(data)
 hubspot.marketingEmail.update(id, data)
+hubspot.marketingEmail.clone(id, data)
 hubspot.marketingEmail.delete(id)
+hubspot.marketingEmail.versions(id)
+hubspot.marketingEmail.restore(id)
+hubspot.marketingEmail.hasBufferedChanges(id)
+hubspot.marketingEmail.statistics(opts)
+hubspot.marketingEmail.statisticsById(id)
 ```
 
 ### Social Media

--- a/lib/marketing_email.js
+++ b/lib/marketing_email.js
@@ -38,10 +38,54 @@ class MarketingEmail {
     })
   }
 
+  clone(id, data) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: `/marketing-emails/v1/emails/${id}/clone`,
+      body: data,
+    })
+  }
+
   delete(id) {
     return this.client.apiRequest({
       method: 'DELETE',
       path: `/marketing-emails/v1/emails/${id}`,
+    })
+  }
+
+  versions(id) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: `/marketing-emails/v1/emails/${id}/versions`,
+    })
+  }
+
+  restore(id) {
+    return this.client.apiRequest({
+      method: 'PUT',
+      path: `/marketing-emails/v1/emails/${id}/restore-deleted`,
+    })
+  }
+
+  hasBufferedChanges(id) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: `/marketing-emails/v1/emails/${id}/has-buffered-changes`,
+    })
+  }
+
+  statistics(options) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: `/marketing-emails/v1/emails/with-statistics`,
+      qs: options,
+    })
+  }
+
+  statisticsById(id) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: `/marketing-emails/v1/emails/with-statistics/${id}`,
     })
   }
 }

--- a/lib/typescript/marketing_email.ts
+++ b/lib/typescript/marketing_email.ts
@@ -11,7 +11,19 @@ declare class MarketingEmail {
 
   update(id: string, data: {}): RequestPromise
 
+  clone(id: string, data: {}): RequestPromise
+
   delete(id: string): RequestPromise
+
+  versions(id: string): RequestPromise
+
+  restore(id: string): RequestPromise
+
+  hasBufferedChanges(id: string): RequestPromise
+
+  statistics(opts?: {}): RequestPromise
+
+  statisticsById(id: string): RequestPromise
 }
 
 export { MarketingEmail }

--- a/test/marketing_email.js
+++ b/test/marketing_email.js
@@ -103,6 +103,35 @@ describe('marketingEmail', () => {
     }
   })
 
+  describe('clone', () => {
+    const id = 'mock_id'
+    const payload = {
+      name: 'New name of a cloned email',
+    }
+
+    const emailEndpoint = {
+      path: `/marketing-emails/v1/emails/${id}/clone`,
+      request: payload,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      postEndpoints: [emailEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can clone a marketing email', () => {
+        return hubspot.marketingEmail.clone(id, payload).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+
   describe('delete', () => {
     const id = 'mock_id'
 
@@ -126,5 +155,108 @@ describe('marketingEmail', () => {
         })
       })
     }
+  })
+
+  describe('versions', () => {
+    let id
+
+    before(() => {
+      return hubspot.marketingEmail.get().then((data) => {
+        id = data.objects[0].id
+      })
+    })
+
+    it('should return the versions of an email', () => {
+      return hubspot.marketingEmail.versions(id).then((data) => {
+        expect(data).to.be.an('array')
+        expect(data.length).to.be.above(0)
+        expect(data[0]).to.be.an('object')
+        expect(data[0].id).to.be.eq(-1)
+        expect(data[0].object).to.be.an('object')
+        expect(data[0].object.id).to.be.eq(id)
+      })
+    })
+  })
+
+  describe('restore', () => {
+    const id = 'mock_id'
+
+    const emailEndpoint = {
+      path: `/marketing-emails/v1/emails/${id}/restore-deleted`,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      putEndpoints: [emailEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can restore a marketing email', () => {
+        return hubspot.marketingEmail.restore(id).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+
+  describe('hasBufferedChanges', () => {
+    let id
+
+    before(() => {
+      return hubspot.marketingEmail.get().then((data) => {
+        id = data.objects[0].id
+      })
+    })
+
+    it('should return whether the email has buffered changes or not', () => {
+      return hubspot.marketingEmail.hasBufferedChanges(id).then((data) => {
+        expect(data).to.be.a('object')
+        expect(data.has_changes).to.be.a('boolean')
+      })
+    })
+  })
+
+  describe('statistics', () => {
+    it('should return all the marketing emails with statistics', () => {
+      return hubspot.marketingEmail.statistics().then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.objects).to.be.a('array')
+        expect(data.objects.length).to.be.above(0)
+        expect(data.objects[0].stats).to.be.an('object')
+      })
+    })
+
+    it('should return a limited number of emails with statistics', () => {
+      return hubspot.marketingEmail.statistics({ limit: 1 }).then((data) => {
+        expect(data.objects).to.be.a('array')
+        expect(data.objects.length).to.be.above(0)
+        expect(data.objects[0].stats).to.be.an('object')
+      })
+    })
+  })
+
+  describe('statisticsById', () => {
+    let id, name, author
+
+    before(() => {
+      return hubspot.marketingEmail.statistics().then((data) => {
+        id = data.objects[0].id
+        name = data.objects[0].name
+        author = data.objects[0].author
+      })
+    })
+
+    it('should return a email with statistics', () => {
+      return hubspot.marketingEmail.statisticsById(id).then((data) => {
+        expect(data).to.be.a('object')
+        expect(data.name).to.eq(name)
+        expect(data.author).to.eq(author)
+        expect(data.stats).to.be.an('object')
+      })
+    })
   })
 })


### PR DESCRIPTION
Why:

- I needed the statistics endpoints for something I was working on, saw other missing endpoints and resolved to add them as well to complete the marketing email file 

This change addresses the need by:

- fixes #260
