### PR TITLE
add support for contact addSecondaryEmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ hubspot.contacts.createOrUpdate(email, data)
 hubspot.contacts.updateByEmail(email, data)
 hubspot.contacts.delete(id)
 hubspot.contacts.merge(primaryId, secondaryId)
+
+// Add a secondary email address to a contact
+hubspot.contacts.addSecondaryEmail(vid, secondaryEmail)
 ```
 
 ### Contact properties

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -142,6 +142,13 @@ class Contact {
       qs: options,
     })
   }
+
+  addSecondaryEmail(vid, secondaryEmail) {
+    return this.client.apiRequest({
+      method: 'PUT',
+      path: `/contacts/v1/secondary-email/${vid}/email/${secondaryEmail}`,
+    })
+  }
 }
 
 module.exports = Contact

--- a/lib/typescript/contact.ts
+++ b/lib/typescript/contact.ts
@@ -44,6 +44,8 @@ declare class Contact {
 
   search(query: string, opts?: {}): RequestPromise
 
+  addSecondaryEmail(vid: string, secondaryEmail: string): RequestPromise
+
   properties: Properties
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/contacts.js
+++ b/test/contacts.js
@@ -505,4 +505,28 @@ describe('contacts', () => {
       })
     })
   })
+
+  describe('addSecondaryEmail', () => {
+    const vid = 123
+    const secondaryEmail = 'test-sec@hubspot.com'
+    const addSecondaryEmailEndpoint = {
+      path: `/contacts/v1/secondary-email/${vid}/email/${secondaryEmail}`,
+      statusCode: 200,
+      response: {
+        vid,
+        secondaryEmails: ['test-sec@hubspot.com'],
+      },
+    }
+    fakeHubspotApi.setupServer({
+      putEndpoints: [addSecondaryEmailEndpoint],
+    })
+
+    it('should Create or Update a contact', () => {
+      return hubspot.contacts.addSecondaryEmail(vid, secondaryEmail).then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.vid).to.be.eq(123)
+        expect(data.secondaryEmails).to.be.eql(['test-sec@hubspot.com'])
+      })
+    })
+  })
 })


### PR DESCRIPTION
Why:
Add support for contact addSecondaryEmail API call

This change addresses the need by:
Lusha.co integration to HubSpot
