### PR TITLE
Fix subscription typescript definition to have unsubscribe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ hubspot.forms.getUploadedFileByUrl(url)
 
 ```javascript
 hubspot.subscriptions.get(opts)
+hubspot.subscriptions.subscribeToAll(email)
+hubspot.subscriptions.unsubscribe(email)
 ```
 
 ### Email Events

--- a/lib/typescript/subscription.ts
+++ b/lib/typescript/subscription.ts
@@ -3,6 +3,7 @@ import { RequestPromise } from 'request-promise'
 declare class Subscription {
   get(opts?: {}): RequestPromise
   subscribeToAll(email: string): RequestPromise
+  unsubscribe(email: string): RequestPromise
 }
 
 export { Subscription }


### PR DESCRIPTION
Why:

- there was missing typescript type definition for unsubscribe() function in lib/typescript/subscription.ts file

This change addresses the need by:

- this change adds needed unsubscribe() function typescript definition
