### PR TITLE
Add Get in Tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,12 @@ const hubspot = new Hubspot(params)
 return hubspot.oauth.getAccessToken(params).then(...)
 ```
 
+### Tickets
+
+```javascript
+hubspot.ticket.getAll()
+```
+
 ## Not wrapped endpoint(s)
 
 It is possible to access the hubspot request method directly,

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ import { Workflow } from './lib/typescript/workflow';
 import {Timeline} from "./lib/typescript/timeline";
 import { RequestPromise } from 'request-promise'
 import { MarketingEmail } from './lib/typescript/marketing_email'
+import { Ticket } from './lib/typescript/ticket';
 
 interface BaseOptions {
   baseUrl?: string
@@ -105,6 +106,7 @@ declare class Hubspot {
   forms: Form
   workflows: Workflow
   marketingEmail: MarketingEmail
+  ticket: Ticket
 }
 
 export default Hubspot

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,6 +23,7 @@ const Subscription = require('./subscription')
 const Timeline = require('./timeline')
 const Workflow = require('./workflow')
 const MarketingEmail = require('./marketing_email')
+const Ticket = require('./ticket')
 
 const debug = require('debug')('hubspot:client')
 
@@ -62,6 +63,7 @@ const setInstances = (client) => {
   client.workflows = new Workflow(client)
   client.crm = new CRM(client)
   client.marketingEmail = new MarketingEmail(client)
+  client.ticket = new Ticket(client)
 }
 
 const prepareParams = (opts, self) => {

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -3,7 +3,7 @@ class Ticket {
     this.client = client
   }
 
-  get(options) {
+  getAll(options) {
     return this.client.apiRequest({
       method: 'GET',
       path: '/crm-objects/v1/objects/tickets/paged',

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -1,0 +1,15 @@
+class Ticket {
+  constructor(client) {
+    this.client = client
+  }
+
+  get(options) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: '/crm-objects/v1/objects/tickets/paged',
+      qs: options,
+    })
+  }
+}
+
+module.exports = Ticket

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -1,7 +1,7 @@
 import { RequestPromise } from 'request-promise'
 
 declare class Ticket {
-  get(opts?: {}): RequestPromise
+  getAll(opts?: {}): RequestPromise
 }
 
 export { Ticket }

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -1,0 +1,7 @@
+import { RequestPromise } from 'request-promise'
+
+declare class Ticket {
+  get(opts?: {}): RequestPromise
+}
+
+export { Ticket }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,8 +1,10 @@
 module.exports = {
-  overrides: [{
-    files: '**/*.js',
-    rules: {
-      'node/no-unpublished-require': 0,
-    }
-  }]
+  overrides: [
+    {
+      files: '**/*.js',
+      rules: {
+        'node/no-unpublished-require': 0,
+      },
+    },
+  ],
 }

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -6,9 +6,9 @@ const apiKey = { apiKey: process.env.HUBSPOT_API_KEY || 'demo' }
 const hubspot = new Hubspot(apiKey)
 
 describe('tickets', () => {
-  describe('get', () => {
+  describe('getAll', () => {
     it('should return all tickets', () => {
-      return hubspot.ticket.get().then((data) => {
+      return hubspot.ticket.getAll().then((data) => {
         expect(data).to.be.an('object')
         expect(data.objects).to.be.a('array')
       })

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -1,0 +1,17 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const Hubspot = require('..')
+const apiKey = { apiKey: process.env.HUBSPOT_API_KEY || 'demo' }
+const hubspot = new Hubspot(apiKey)
+
+describe('tickets', () => {
+  describe('get', () => {
+    it('should return all tickets', () => {
+      return hubspot.ticket.get().then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.objects).to.be.a('array')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Why:

- Get all tickets through the API could be useful for some developers.

This change addresses the need by:

- Adds the get methods in Tickets along with its test case.
