### PR TITLE
Add Create, Delete and Update to Tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,27 @@ return hubspot.oauth.getAccessToken(params).then(...)
 ### Tickets
 
 ```javascript
-hubspot.ticket.getAll()
+const data = [
+  {
+    name: 'subject',
+    value: 'This is an example ticket'
+  },
+  {
+    name: 'content',
+    value: 'Here are the details of the ticket.'
+  },
+  {
+    name: 'hs_pipeline',
+    value: '0'
+  },
+  {
+    name: 'hs_pipeline_stage',
+    value: '1'
+  }
+];
+hubspot.tickets.create(data);
+hubspot.tickets.getAll();
+hubspot.tickets.delete(id);
 ```
 
 ## Not wrapped endpoint(s)

--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ const data = [
 hubspot.tickets.create(data);
 hubspot.tickets.getAll();
 hubspot.tickets.delete(id);
+hubspot.tickets.update(id, newData);
 ```
 
 ## Not wrapped endpoint(s)

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ declare class Hubspot {
   forms: Form
   workflows: Workflow
   marketingEmail: MarketingEmail
-  ticket: Ticket
+  tickets: Ticket
 }
 
 export default Hubspot

--- a/lib/client.js
+++ b/lib/client.js
@@ -63,7 +63,7 @@ const setInstances = (client) => {
   client.workflows = new Workflow(client)
   client.crm = new CRM(client)
   client.marketingEmail = new MarketingEmail(client)
-  client.ticket = new Ticket(client)
+  client.tickets = new Ticket(client)
 }
 
 const prepareParams = (opts, self) => {

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -25,6 +25,14 @@ class Ticket {
       path: `/crm-objects/v1/objects/tickets/${id}`,
     })
   }
+
+  update(id, data) {
+    return this.client.apiRequest({
+      method: 'PUT',
+      path: `/crm-objects/v1/objects/tickets/${id}`,
+      body: data,
+    })
+  }
 }
 
 module.exports = Ticket

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -10,6 +10,21 @@ class Ticket {
       qs: options,
     })
   }
+
+  create(data) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: '/crm-objects/v1/objects/tickets',
+      body: data,
+    })
+  }
+
+  delete(id) {
+    return this.client.apiRequest({
+      method: 'DELETE',
+      path: `/crm-objects/v1/objects/tickets/${id}`,
+    })
+  }
 }
 
 module.exports = Ticket

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -2,6 +2,10 @@ import { RequestPromise } from 'request-promise'
 
 declare class Ticket {
   getAll(opts?: {}): RequestPromise
+
+  create(data: {}): RequestPromise
+
+  delete(id: number): RequestPromise
 }
 
 export { Ticket }

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -6,6 +6,8 @@ declare class Ticket {
   create(data: {}): RequestPromise
 
   delete(id: number): RequestPromise
+
+  update(id: number, data: {}): RequestPromise
 }
 
 export { Ticket }

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -85,4 +85,38 @@ describe('tickets', () => {
       })
     }
   })
+
+  describe('update', () => {
+    const id = 'mock_id'
+    const newData = {
+      properties: [
+        {
+          name: 'content',
+          value: 'This is now an updated ticket marked as high priority.',
+        },
+      ],
+    }
+
+    const ticketsEndpoint = {
+      path: `/crm-objects/v1/objects/tickets/${id}`,
+      request: newData,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      putEndpoints: [ticketsEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can update a ticket', () => {
+        return hubspot.tickets.update(id, newData).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
 })

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -2,16 +2,87 @@ const chai = require('chai')
 const expect = chai.expect
 
 const Hubspot = require('..')
+const fakeHubspotApi = require('./helpers/fake_hubspot_api')
 const apiKey = { apiKey: process.env.HUBSPOT_API_KEY || 'demo' }
 const hubspot = new Hubspot(apiKey)
 
 describe('tickets', () => {
   describe('getAll', () => {
     it('should return all tickets', () => {
-      return hubspot.ticket.getAll().then((data) => {
+      return hubspot.tickets.getAll().then((data) => {
         expect(data).to.be.an('object')
         expect(data.objects).to.be.a('array')
       })
     })
+  })
+
+  describe('create', () => {
+    const newTicket = {
+      properties: [
+        {
+          name: 'subject',
+          value: 'This is an example ticket',
+        },
+        {
+          name: 'content',
+          value: 'Here are the details of the ticket.',
+        },
+        {
+          name: 'hs_pipeline',
+          value: '0',
+        },
+        {
+          name: 'hs_pipeline_stage',
+          value: '1',
+        },
+      ],
+    }
+
+    const ticketsEndpoint = {
+      path: '/crm-objects/v1/objects/tickets',
+      request: newTicket,
+      response: { properties: { subject: { value: 'This is an example ticket' } } },
+    }
+
+    fakeHubspotApi.setupServer({
+      postEndpoints: [ticketsEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should create a ticket in a given portal', () => {
+        return hubspot.tickets.create(newTicket).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.properties.subject.value).to.equal('This is an example ticket')
+        })
+      })
+    }
+  })
+
+  describe('delete', () => {
+    const id = 'fake_id'
+
+    const ticketsEndpoint = {
+      path: `/crm-objects/v1/objects/tickets/${id}`,
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({
+      deleteEndpoints: [ticketsEndpoint],
+      demo: true,
+    })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can delete', () => {
+        return hubspot.tickets.delete(id).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
   })
 })


### PR DESCRIPTION
Why:

- Users could create a new ticket, and delete or update an existing ticket as needed.

This change addresses the need by:

- Added create, delete and update methods to Tickets with test cases.
