### PR TITLE
Add Batch Methods (GetById, Create, Delete and Update) and Specific Get Methods to Tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,10 +489,43 @@ const data = [
     value: '1'
   }
 ];
+const ids = [176606, 177919];
+const newDataId = [
+    {
+      objectId: 176606,
+      properties: [
+        {
+          name: 'subject',
+          value: 'SUBJECT 001'
+        },
+        {
+          name: 'content',
+          value: 'TICKET 001'
+        }
+      ]
+    },
+    {
+      objectId: 177919,
+      properties: [
+        {
+          name: 'subject',
+          value: 'SUBJECT 002'
+        },
+        {
+          name: 'content',
+          value: 'TICKET 002'
+        }
+      ]
+    }
+  ];
+
 hubspot.tickets.create(data);
+hubspot.tickets.createBatch(data);
 hubspot.tickets.getAll();
 hubspot.tickets.delete(id);
+hubspot.tickets.deleteBatch(ids);
 hubspot.tickets.update(id, newData);
+hubspot.tickets.updateBatch(newDataId);
 ```
 
 ## Not wrapped endpoint(s)

--- a/README.md
+++ b/README.md
@@ -522,6 +522,9 @@ const newDataId = [
 hubspot.tickets.create(data);
 hubspot.tickets.createBatch(data);
 hubspot.tickets.getAll();
+hubspot.tickets.getAll(['subject', 'content']);
+hubspot.tickets.getById(id);
+hubspot.tickets.getById(id, ['subject', 'content']);
 hubspot.tickets.delete(id);
 hubspot.tickets.deleteBatch(ids);
 hubspot.tickets.update(id, newData);

--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ const data = [
   }
 ];
 const ids = [176606, 177919];
+const properties = ['subject', 'content', 'hs_pipeline'];
 const newDataId = [
     {
       objectId: 176606,
@@ -522,9 +523,11 @@ const newDataId = [
 hubspot.tickets.create(data);
 hubspot.tickets.createBatch(data);
 hubspot.tickets.getAll();
-hubspot.tickets.getAll(['subject', 'content']);
+hubspot.tickets.getAll(properties);
 hubspot.tickets.getById(id);
-hubspot.tickets.getById(id, ['subject', 'content']);
+hubspot.tickets.getById(id, properties);
+hubspot.tickets.getBatchById(ids);
+hubspot.tickets.getBatchById(ids, properties);
 hubspot.tickets.delete(id);
 hubspot.tickets.deleteBatch(ids);
 hubspot.tickets.update(id, newData);

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -3,11 +3,19 @@ class Ticket {
     this.client = client
   }
 
-  getAll(options) {
+  getAll(properties) {
     return this.client.apiRequest({
       method: 'GET',
       path: '/crm-objects/v1/objects/tickets/paged',
-      qs: options,
+      qs: { properties },
+    })
+  }
+
+  getById(id, properties) {
+    return this.client.apiRequest({
+      method: 'GET',
+      path: `/crm-objects/v1/objects/tickets/${id}`,
+      qs: { properties },
     })
   }
 

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -19,6 +19,14 @@ class Ticket {
     })
   }
 
+  createBatch(data) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: '/crm-objects/v1/objects/tickets/batch-create',
+      body: data,
+    })
+  }
+
   delete(id) {
     return this.client.apiRequest({
       method: 'DELETE',

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -41,6 +41,14 @@ class Ticket {
       body: data,
     })
   }
+
+  updateBatch(data) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: '/crm-objects/v1/objects/tickets/batch-update',
+      body: data,
+    })
+  }
 }
 
 module.exports = Ticket

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -19,6 +19,15 @@ class Ticket {
     })
   }
 
+  getBatchById(ids, properties) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: '/crm-objects/v1/objects/tickets/batch-read',
+      body: { ids },
+      qs: { properties },
+    })
+  }
+
   create(data) {
     return this.client.apiRequest({
       method: 'POST',

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -34,6 +34,14 @@ class Ticket {
     })
   }
 
+  deleteBatch(ids) {
+    return this.client.apiRequest({
+      method: 'POST',
+      path: '/crm-objects/v1/objects/tickets/batch-delete',
+      body: { ids },
+    })
+  }
+
   update(id, data) {
     return this.client.apiRequest({
       method: 'PUT',

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -15,9 +15,11 @@ export interface ITicketUpdate {
 }
 
 declare class Ticket {
-  getAll(properties?: []): RequestPromise
+  getAll(properties?: string[]): RequestPromise
 
-  getById(id: number, properties?: []): RequestPromise
+  getById(id: number, properties?: string[]): RequestPromise
+
+  getBatchById(ids: number[], properties?: string[]): RequestPromise
 
   create(data: ITicket): RequestPromise
 

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -23,6 +23,8 @@ declare class Ticket {
 
   delete(id: number): RequestPromise
 
+  deleteBatch(ids: number[]): RequestPromise
+
   update(id: number, data: {}): RequestPromise
 
   updateBatch(data: ITicketUpdate[]): RequestPromise

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -1,6 +1,6 @@
 import { RequestPromise } from 'request-promise'
 
-export interface IHubspotTicket {
+export interface ITicket {
   subject: string
   content: string
   due_date: number
@@ -9,16 +9,23 @@ export interface IHubspotTicket {
   hs_pipeline_stage: number
 }
 
+export interface ITicketUpdate {
+  objectId: number
+  properties: any[]
+}
+
 declare class Ticket {
   getAll(opts?: {}): RequestPromise
 
-  create(data: IHubspotTicket): RequestPromise
+  create(data: ITicket): RequestPromise
 
-  createBatch(data: IHubspotTicket[]): RequestPromise
+  createBatch(data: ITicket[]): RequestPromise
 
   delete(id: number): RequestPromise
 
   update(id: number, data: {}): RequestPromise
+
+  updateBatch(data: ITicketUpdate[]): RequestPromise
 }
 
 export { Ticket }

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -1,9 +1,20 @@
 import { RequestPromise } from 'request-promise'
 
+export interface IHubspotTicket {
+  subject: string
+  content: string
+  due_date: number
+  hs_ticket_priority: string
+  hs_pipeline: number
+  hs_pipeline_stage: number
+}
+
 declare class Ticket {
   getAll(opts?: {}): RequestPromise
 
-  create(data: {}): RequestPromise
+  create(data: IHubspotTicket): RequestPromise
+
+  createBatch(data: IHubspotTicket[]): RequestPromise
 
   delete(id: number): RequestPromise
 

--- a/lib/typescript/ticket.ts
+++ b/lib/typescript/ticket.ts
@@ -15,7 +15,9 @@ export interface ITicketUpdate {
 }
 
 declare class Ticket {
-  getAll(opts?: {}): RequestPromise
+  getAll(properties?: []): RequestPromise
+
+  getById(id: number, properties?: []): RequestPromise
 
   create(data: ITicket): RequestPromise
 

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -11,7 +11,39 @@ describe('tickets', () => {
     it('should return all tickets', () => {
       return hubspot.tickets.getAll().then((data) => {
         expect(data).to.be.an('object')
-        expect(data.objects).to.be.a('array')
+        expect(data.objects).to.be.an('array')
+      })
+    })
+
+    it('should return all tickets with properties', () => {
+      const properties = ['subject', 'content', 'hs_pipeline', 'hs_pipeline_stage']
+      return hubspot.tickets.getAll(properties).then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.objects).to.be.an('array')
+      })
+    })
+  })
+
+  describe('getById', () => {
+    let ticketId
+
+    before(() => {
+      return hubspot.tickets.getAll().then((data) => {
+        ticketId = data.objects[0].objectId
+      })
+    })
+
+    it('should return a ticket by ID', () => {
+      return hubspot.tickets.getById(ticketId).then((data) => {
+        expect(data).to.be.an('object')
+      })
+    })
+
+    it('should return a ticket by ID with properties', () => {
+      const properties = ['subject', 'content', 'hs_pipeline', 'hs_pipeline_stage']
+      return hubspot.tickets.getById(ticketId, properties).then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.properties).to.be.an('object')
       })
     })
   })

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -48,6 +48,44 @@ describe('tickets', () => {
     })
   })
 
+  describe('getBatchById', () => {
+    const ticketIds = ['fake_id_1', 'fake_id_2']
+
+    const ticketsByIdEndpoint = {
+      path: '/crm-objects/v1/objects/tickets/batch-read',
+      request: { ids: ticketIds },
+      response: { success: true },
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [ticketsByIdEndpoint], demo: true })
+
+    it('should return multiple tickets by IDs', () => {
+      return hubspot.tickets.getBatchById(ticketIds).then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.success).to.be.eq(true)
+      })
+    })
+  })
+
+  describe('getBatchById with properties', () => {
+    const ticketIds = ['fake_id_1', 'fake_id_2']
+
+    const ticketsByIdEndpoint = {
+      path: '/crm-objects/v1/objects/tickets/batch-read',
+      query: { properties: ['subject', 'content', 'hs_pipeline', 'hs_pipeline_stage'] },
+      request: { ids: ticketIds },
+      response: { success: true },
+    }
+    fakeHubspotApi.setupServer({ postEndpoints: [ticketsByIdEndpoint], demo: true })
+
+    it('should return multiple tickets by IDs with properties', () => {
+      const properties = ['subject', 'content', 'hs_pipeline', 'hs_pipeline_stage']
+      return hubspot.tickets.getBatchById(ticketIds, properties).then((data) => {
+        expect(data).to.be.an('object')
+        expect(data.success).to.be.eq(true)
+      })
+    })
+  })
+
   describe('create', () => {
     const subjectValue = 'This is an example ticket'
     const newTicket = {

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -17,11 +17,12 @@ describe('tickets', () => {
   })
 
   describe('create', () => {
+    const subjectValue = 'This is an example ticket'
     const newTicket = {
       properties: [
         {
           name: 'subject',
-          value: 'This is an example ticket',
+          value: subjectValue,
         },
         {
           name: 'content',
@@ -41,13 +42,10 @@ describe('tickets', () => {
     const ticketsEndpoint = {
       path: '/crm-objects/v1/objects/tickets',
       request: newTicket,
-      response: { properties: { subject: { value: 'This is an example ticket' } } },
+      response: { properties: { subject: { value: subjectValue } } },
     }
 
-    fakeHubspotApi.setupServer({
-      postEndpoints: [ticketsEndpoint],
-      demo: true,
-    })
+    fakeHubspotApi.setupServer({ postEndpoints: [ticketsEndpoint], demo: true })
 
     if (process.env.NOCK_OFF) {
       it('will not run with NOCK_OFF set to true. See commit message.')
@@ -55,7 +53,78 @@ describe('tickets', () => {
       it('should create a ticket in a given portal', () => {
         return hubspot.tickets.create(newTicket).then((data) => {
           expect(data).to.be.an('object')
-          expect(data.properties.subject.value).to.equal('This is an example ticket')
+          expect(data.properties.subject.value).to.equal(subjectValue)
+        })
+      })
+    }
+  })
+
+  describe('createBatch', () => {
+    const subjectValue = 'This is an example ticket'
+    const anotherSubjectValue = 'This is another example ticket'
+    const newTickets = [
+      [
+        {
+          name: 'subject',
+          value: subjectValue,
+        },
+        {
+          name: 'content',
+          value: 'Here are the details of the ticket.',
+        },
+        {
+          name: 'hs_pipeline',
+          value: 0,
+        },
+        {
+          name: 'hs_pipeline_stage',
+          value: 1,
+        },
+        {
+          name: 'hs_ticket_priority',
+          value: 'HIGH',
+        },
+      ],
+      [
+        {
+          name: 'subject',
+          value: anotherSubjectValue,
+        },
+        {
+          name: 'content',
+          value: 'Here are the details of the ticket.',
+        },
+        {
+          name: 'hs_pipeline',
+          value: 0,
+        },
+        {
+          name: 'hs_pipeline_stage',
+          value: 1,
+        },
+        {
+          name: 'hs_ticket_priority',
+          value: 'HIGH',
+        },
+      ],
+    ]
+
+    const ticketsEndpoint = {
+      path: '/crm-objects/v1/objects/tickets/batch-create',
+      request: newTickets,
+      response: [{ subject: { value: subjectValue } }, { subject: { value: anotherSubjectValue } }],
+    }
+
+    fakeHubspotApi.setupServer({ postEndpoints: [ticketsEndpoint], demo: true })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should create a ticket in a given portal', () => {
+        return hubspot.tickets.createBatch(newTickets).then((data) => {
+          expect(data).to.be.an('array')
+          expect(data[0].subject.value).to.equal(subjectValue)
+          expect(data[1].subject.value).to.equal(anotherSubjectValue)
         })
       })
     }

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -120,7 +120,7 @@ describe('tickets', () => {
     if (process.env.NOCK_OFF) {
       it('will not run with NOCK_OFF set to true. See commit message.')
     } else {
-      it('should create a ticket in a given portal', () => {
+      it('should create multiple tickets in a given portal', () => {
         return hubspot.tickets.createBatch(newTickets).then((data) => {
           expect(data).to.be.an('array')
           expect(data[0].subject.value).to.equal(subjectValue)
@@ -138,10 +138,7 @@ describe('tickets', () => {
       response: { success: true },
     }
 
-    fakeHubspotApi.setupServer({
-      deleteEndpoints: [ticketsEndpoint],
-      demo: true,
-    })
+    fakeHubspotApi.setupServer({ deleteEndpoints: [ticketsEndpoint], demo: true })
 
     if (process.env.NOCK_OFF) {
       it('will not run with NOCK_OFF set to true. See commit message.')
@@ -172,10 +169,7 @@ describe('tickets', () => {
       response: { success: true },
     }
 
-    fakeHubspotApi.setupServer({
-      putEndpoints: [ticketsEndpoint],
-      demo: true,
-    })
+    fakeHubspotApi.setupServer({ putEndpoints: [ticketsEndpoint], demo: true })
 
     if (process.env.NOCK_OFF) {
       it('will not run with NOCK_OFF set to true. See commit message.')
@@ -184,6 +178,62 @@ describe('tickets', () => {
         return hubspot.tickets.update(id, newData).then((data) => {
           expect(data).to.be.an('object')
           expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+
+  describe('updateBatch', () => {
+    const newSubject = 'NEW SUBJECT'
+    const anotherSubject = 'ANOTHER SUBJECT'
+    const newData = [
+      {
+        objectId: 'mock_id_one',
+        properties: [
+          {
+            name: 'subject',
+            value: newSubject,
+          },
+          {
+            name: 'content',
+            value: 'NEW TICKET...',
+          },
+        ],
+      },
+      {
+        objectId: 'mock_id_two',
+        properties: [
+          {
+            name: 'subject',
+            value: anotherSubject,
+          },
+          {
+            name: 'content',
+            value: 'ANOTHER TICKET...',
+          },
+        ],
+      },
+    ]
+
+    const ticketsEndpoint = {
+      path: `/crm-objects/v1/objects/tickets/batch-update`,
+      request: newData,
+      response: [
+        { properties: { subject: { value: newSubject } } },
+        { properties: { subject: { value: anotherSubject } } },
+      ],
+    }
+
+    fakeHubspotApi.setupServer({ postEndpoints: [ticketsEndpoint], demo: true })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('can update multiple tickets', () => {
+        return hubspot.tickets.updateBatch(newData).then((data) => {
+          expect(data).to.be.an('array')
+          expect(data[0].properties.subject.value).to.equal(newSubject)
+          expect(data[1].properties.subject.value).to.equal(anotherSubject)
         })
       })
     }

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -152,6 +152,29 @@ describe('tickets', () => {
     }
   })
 
+  describe('deleteBatch', () => {
+    const ids = ['fake_id_one', 'fake_id_two']
+
+    const ticketsEndpoint = {
+      path: '/crm-objects/v1/objects/tickets/batch-delete',
+      request: { ids },
+      response: { success: true },
+    }
+
+    fakeHubspotApi.setupServer({ postEndpoints: [ticketsEndpoint], demo: true })
+
+    if (process.env.NOCK_OFF) {
+      it('will not run with NOCK_OFF set to true. See commit message.')
+    } else {
+      it('should delete multiple tickets in a given portal', () => {
+        return hubspot.tickets.deleteBatch(ids).then((data) => {
+          expect(data).to.be.an('object')
+          expect(data.success).to.be.eq(true)
+        })
+      })
+    }
+  })
+
   describe('update', () => {
     const id = 'mock_id'
     const newData = {


### PR DESCRIPTION
Why:

- Users could batch create new tickets, and batch delete or batch update existing tickets.
- Users could get all tickets (or by ticket id) with or without optional properties.

This change addresses the need by:

- Added batch create, batch delete and batch update methods to Tickets with test cases.
- Added properties to getAll method in Tickets.
- Added getById method in Tickets with optional properties.
- Added batch get by id in Tickets.
