### PR TITLE
files.upload: fix override&hidden params

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -22,8 +22,8 @@ const getFormData = ({ name, content, folderId, folderPath }) => {
 const getUrlForFileUpload = (client, override, hidden) => {
   const hapikey = _.get(client, 'qs.hapikey')
   const params = {}
-  if (override) params.override = override
-  if (hidden) params.override = hidden
+  if (!_.isUndefined(override)) params.override = override
+  if (!_.isUndefined(hidden)) params.hidden = hidden
   if (hapikey) params.hapikey = hapikey
   const queryPart = _.isEmpty(params) ? '' : `?${qs.stringify(params)}`
 

--- a/test/files.js
+++ b/test/files.js
@@ -42,7 +42,8 @@ describe('files', () => {
     const uploadEndpoint = {
       path: '/filemanager/api/v2/files',
       query: {
-        override: 'true',
+        override: true,
+        hidden: false,
         hapikey: 'demo',
       },
       response: { success: true },
@@ -72,7 +73,8 @@ describe('files', () => {
     const uploadEndpoint = {
       path: '/filemanager/api/v2/files',
       query: {
-        override: 'true',
+        override: true,
+        hidden: false,
         hapikey: 'demo',
       },
       response: { success: true },


### PR DESCRIPTION
**Why:**
the param "hidden" is fully ignored.
the param "override" work incorrectly in case it's === false.
