### PR TITLE
files.upload: fix overwrite param

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -19,10 +19,10 @@ const getFormData = ({ name, content, folderId, folderPath }) => {
   return formData
 }
 
-const getUrlForFileUpload = (client, override, hidden) => {
+const getUrlForFileUpload = (client, overwrite, hidden) => {
   const hapikey = _.get(client, 'qs.hapikey')
   const params = {}
-  if (!_.isUndefined(override)) params.override = override
+  if (!_.isUndefined(overwrite)) params.overwrite = overwrite
   if (!_.isUndefined(hidden)) params.hidden = hidden
   if (hapikey) params.hapikey = hapikey
   const queryPart = _.isEmpty(params) ? '' : `?${qs.stringify(params)}`
@@ -49,7 +49,7 @@ class File {
     })
   }
 
-  async uploadByUrl(fileDetails, override, hidden) {
+  async uploadByUrl(fileDetails, overwrite, hidden) {
     const headers = {
       authorization: `Bearer ${getAccessToken(this.client)}`,
     }
@@ -60,17 +60,17 @@ class File {
     })
     const content = await fetchFileResult.arrayBuffer()
     const uploadDetails = _.assign({}, fileDetails, { content })
-    return this.upload(uploadDetails, override, hidden)
+    return this.upload(uploadDetails, overwrite, hidden)
   }
 
-  async upload(fileDetails, override, hidden) {
+  async upload(fileDetails, overwrite, hidden) {
     const body = getFormData(fileDetails)
     const headers = body.getHeaders()
     headers.authorization = `Bearer ${getAccessToken(this.client)}`
 
     // can't use the request-promise based client because they don't handle formdata inside
     // of body correctly. See: https://github.com/request/request-promise/issues/271
-    const result = await fetch(getUrlForFileUpload(this.client, override, hidden), {
+    const result = await fetch(getUrlForFileUpload(this.client, overwrite, hidden), {
       method: 'POST',
       body,
       headers,

--- a/test/files.js
+++ b/test/files.js
@@ -42,7 +42,7 @@ describe('files', () => {
     const uploadEndpoint = {
       path: '/filemanager/api/v2/files',
       query: {
-        override: true,
+        overwrite: true,
         hidden: false,
         hapikey: 'demo',
       },
@@ -73,7 +73,7 @@ describe('files', () => {
     const uploadEndpoint = {
       path: '/filemanager/api/v2/files',
       query: {
-        override: true,
+        overwrite: true,
         hidden: false,
         hapikey: 'demo',
       },


### PR DESCRIPTION
Why:

- 'override' is not the correct name of the 'overwrite' param. Documentation: https://developers.hubspot.com/docs/methods/files/post_files