### PR TITLE
Fix: TypeError: fetch is not a function

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
 const qs = require('querystring')
-const fetch = require('node-fetch')
+const fetch = require('node-fetch').default
 const FormData = require('form-data')
 
 const getAccessToken = (client) => {


### PR DESCRIPTION
Why:
It throws an error if run it on aws lambda:
`TypeError: o is not a function at e.exports.upload (/var/task/webpack:/node_modules/hubspot/lib/file.js:73:26)`
 
A discussion about this issue: https://github.com/node-fetch/node-fetch/issues/450#issuecomment-387045223
