### PR TITLE
Explicitly export types from file.ts

### DIFF
--- a/lib/typescript/file.ts
+++ b/lib/typescript/file.ts
@@ -74,4 +74,4 @@ declare class File {
   ): RequestPromise
 }
 
-export { File, HubspotFile, HubspotImage }
+export type { File, HubspotFile, HubspotImage }


### PR DESCRIPTION
### Why

We're using node-hubspot as a part of a NextJS with Typescript. NextJS enforces use of `isolatedModules` with TS. And the TS compiler threw this error when we tried to build after adding `hubspot`:

```
../../node_modules/hubspot/lib/typescript/file.ts:77:29 - error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

77 export { File, HubspotFile, HubspotImage }                               ~~~~~~~~~~~~
```

### This change addresses the need by:

Adding `type` to the export statement in `file.ts`

### Contributing guidelines

- [x] Run `npm run build`

---

Thank you for the work you're doing on this package! 🙏
