### PR TITLE
fix(subscription): retrieve all subscription to subscribeToAll

### DIFF
--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -21,12 +21,25 @@ class Subscription {
     })
   }
 
-  subscribeToAll(email) {
+  async subscribeToAll(email) {
+    const subscriptionsTypes = await this.client.apiRequest({
+      method: 'GET',
+      path: `/email/public/v1/subscriptions`,
+    })
+
+    const subscriptionStatuses = subscriptionsTypes.subscriptionDefinitions
+      .filter((subscriptionDefinition) => subscriptionDefinition.active)
+      .map((subscriptionDefinition) => ({
+        id: subscriptionDefinition.id,
+        subscribed: true,
+        optState: 'OPT_IN',
+      }))
+
     return this.client.apiRequest({
       method: 'PUT',
       path: `/email/public/v1/subscriptions/${email}`,
       body: {
-        subscribed: true,
+        subscriptionStatuses,
       },
     })
   }

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -18,8 +18,53 @@ describe('subscriptions', () => {
   })
 
   describe('subscribeToAll', () => {
+    const getEndpoint = {
+      path: `/email/public/v1/subscriptions`,
+      response: {
+        subscriptionDefinitions: [
+          {
+            id: 10,
+            portalId: 1,
+            name: 'Product & Marketing Information',
+            description: 'New product feature updates & Marketing offers.',
+            active: true,
+            internal: false,
+            category: 'Marketing',
+            channel: 'Email',
+            order: 0,
+            internalName: 'MARKETING_INFORMATION',
+          },
+          {
+            id: 11,
+            portalId: 1,
+            name: 'One to One',
+            description: 'One to One emails',
+            active: true,
+            internal: true,
+            category: 'Sales',
+            channel: 'Email',
+            order: 5,
+            internalName: 'ONE_TO_ONE',
+          },
+        ],
+      },
+    }
+
     const email = 'example@domain.com'
-    const expectedBody = { subscribed: true }
+    const expectedBody = {
+      subscriptionStatuses: [
+        {
+          id: 10,
+          subscribed: true,
+          optState: 'OPT_IN',
+        },
+        {
+          id: 11,
+          subscribed: true,
+          optState: 'OPT_IN',
+        },
+      ],
+    }
     const formEndpoint = {
       path: `/email/public/v1/subscriptions/${email}`,
       request: expectedBody,
@@ -28,6 +73,7 @@ describe('subscriptions', () => {
 
     fakeHubspotApi.setupServer({
       putEndpoints: [formEndpoint],
+      getEndpoints: [getEndpoint],
       demo: true,
     })
 


### PR DESCRIPTION
Why:

- Subscribe to all was not working anymore (it does a 201, but in fact the contact was unmodified)

The correct way to subscribe to all communication subscriptions is first to retrieve all subscriptions types ids, and then to send the array with all those ids


